### PR TITLE
docs: add styreportal to app Hetzner status table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Prosjektoversikt
 
-**Safekeeper** - Parametrisert Docker-image for automatisk PostgreSQL-backup med lokal lagring (NAS) og offsite-backup til Hetzner StorageBox (SSH/SCP). Brukes av alle Kotlin/Ktor-appene i portefoljen (lo-finans, biologportal, 6810, summa-summarum).
+**Safekeeper** - Parametrisert Docker-image for automatisk PostgreSQL-backup med lokal lagring (NAS) og offsite-backup til Hetzner StorageBox (SSH/SCP). Brukes av alle Kotlin/Ktor-appene i portefoljen (lo-finans, biologportal, 6810, summa-summarum, styreportal).
 
 Alt styres via miljovariabler - ingen prosjektspesifikk kode. Samme image brukes av alle apper.
 
@@ -230,6 +230,7 @@ backup:
 | lo-finans | `/mnt/nas-apps/lo-finans/backups` | Venter pa opprettelse | `0 5 * * *` |
 | 6810 | `/mnt/nas-apps/6810/backups` | Venter pa opprettelse | `0 5 * * *` |
 | summa-summarum | `/mnt/nas-apps/summa-summarum/backups` | Venter pa opprettelse | `0 5 * * *` |
+| styreportal | `/mnt/nas-apps/styreportal/backups` | Venter pa opprettelse | `30 1 * * *` |
 
 ### Kryssrepo-avhengigheter
 


### PR DESCRIPTION
Automatisk dokumentasjonsoppdatering: Legger til styreportal i tabellen over apper som bruker safekeeper.