### PR TITLE
fix: file backup verification, Hetzner checksums, pin ShellCheck

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ludeeus/action-shellcheck@master
+      - uses: ludeeus/action-shellcheck@2.0.0
         with:
           scandir: '.'
 

--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -183,6 +183,8 @@ run_backup() {
 
     # Last opp til Hetzner StorageBox (offsite) med retry
     upload_with_retry "$backup_file"
+    # Last opp checksum-fil til Hetzner
+    upload_with_retry "${backup_file}.sha256"
 
     # Slett lokale backups eldre enn BACKUP_RETENTION_DAYS
     find "$BACKUP_DIR" -name "${PROJECT_NAME}_*.sql.gz.gpg" -mtime "+${BACKUP_RETENTION_DAYS}" -delete 2>/dev/null || true
@@ -230,6 +232,13 @@ backup_files() {
         > "$backup_file"
     chmod 600 "$backup_file"
 
+    # Verifiser at fil-backup er gyldig (dekrypterings-test)
+    if ! gpg --batch --yes --decrypt \
+        --passphrase-fd 3 3< <(printf '%s' "$BACKUP_ENCRYPTION_KEY") \
+        < "$backup_file" | tar tzf - > /dev/null 2>&1; then
+        error "Fil-backup-verifisering feilet! Kryptert arkiv kan ikke dekrypteres/pakkes ut."
+    fi
+
     local size
     size=$(du -h "$backup_file" | cut -f1)
 
@@ -241,6 +250,8 @@ backup_files() {
 
     # Last opp til Hetzner med retry
     upload_with_retry "$backup_file"
+    # Last opp checksum-fil til Hetzner
+    upload_with_retry "${backup_file}.sha256"
 
     # Rydd opp gamle fil-backups
     find "$BACKUP_DIR" -name "${PROJECT_NAME}_files_*.tar.gz.gpg" -mtime "+${BACKUP_RETENTION_DAYS}" -delete 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Add integrity verification (decrypt+extract test) for file backups — matching existing database backup verification
- Upload .sha256 checksum files to Hetzner alongside backup files for offsite checksum verification
- Pin `ludeeus/action-shellcheck` to `v2.0.0` instead of `@master` (supply chain risk)

## Test plan
- [x] Docker image builds successfully
- [x] ShellCheck CI passes with pinned version
- [x] Hadolint CI passes
- [ ] Manual backup test in next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)