### PR TITLE
Fix #7: BATS stubs + run_backup happy-path tests

### DIFF
--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -15,6 +15,7 @@ PROJECT_NAME="${PROJECT_NAME:?Manglende miljovariabel: PROJECT_NAME}"
 BACKUP_DIR="${BACKUP_DIR:-/backups}"
 BACKUP_SCHEDULE="${BACKUP_SCHEDULE:-0 5 * * *}"
 BACKUP_RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-30}"
+BACKUP_SUCCESS_FILE="${BACKUP_SUCCESS_FILE:-/tmp/last-backup-success}"
 
 DB_HOST="${DB_HOST:-postgres}"
 DB_PORT="${DB_PORT:-5432}"
@@ -196,7 +197,7 @@ run_backup() {
     cleanup_hetzner
 
     log "Backup fullfort OK"
-    date +%s > /tmp/last-backup-success
+    date +%s > "$BACKUP_SUCCESS_FILE"
 }
 
 upload_with_retry() {
@@ -260,7 +261,7 @@ backup_files() {
     find "$BACKUP_DIR" -name "${PROJECT_NAME}_files_*.tar.gz" -not -name "*.gpg" -mtime "+${BACKUP_RETENTION_DAYS}" -delete 2>/dev/null || true
 
     log "Fil-backup fullfort OK"
-    date +%s > /tmp/last-backup-success
+    date +%s > "$BACKUP_SUCCESS_FILE"
 }
 
 main() {

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,8 +25,26 @@ bats tests/
 tests/
   run.sh                     # Wrapper for lokal kjøring
   helpers/
-    common.bash              # Felles oppsett (SAFEKEEPER_ROOT osv.)
+    common.bash              # Felles oppsett (SAFEKEEPER_ROOT, setup_stubs)
+  stubs/
+    pg_isready               # Stub for PostgreSQL-helsesjekk
+    pg_dump                  # Stub som skriver dummy-SQL til stdout
+    gpg                      # Stub som pipe-through stdin (virker for --symmetric og --decrypt)
+    sleep                    # Stub som returnerer umiddelbart
   check_requirements.bats    # Tester for manglende miljøvariabler
+  run_backup.bats            # Tester for happy-path backup-flyt
 ```
 
-Flere testfiler, stub-binærer for `gpg`/`pg_dump`/`scp`/`ssh` og CI-integrasjon legges til i oppfølgende issues (se #4).
+## Stubs og scenariovariasjon
+
+Stub-binærene i `tests/stubs/` prependes til `PATH` via `setup_stubs()` i `helpers/common.bash`. De støtter scenariovariasjon via miljøvariabler:
+
+| Variabel | Effekt |
+|----------|--------|
+| `STUB_GPG_FAIL=1` | `gpg` returnerer 1 |
+| `STUB_PGDUMP_FAIL=1` | `pg_dump` returnerer 1 |
+| `STUB_PGISREADY_FAIL=1` | `pg_isready` returnerer 1 |
+
+For testisolasjon kan `BACKUP_SUCCESS_FILE` settes til en mktemp-sti i stedet for den hardkodede `/tmp/last-backup-success`.
+
+Flere testfiler for `restore.sh` og Hetzner-retry-logikk, samt CI-integrasjon, legges til i oppfølgende issues (se #4).

--- a/tests/helpers/common.bash
+++ b/tests/helpers/common.bash
@@ -4,3 +4,10 @@
 
 SAFEKEEPER_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 export SAFEKEEPER_ROOT
+
+# Prepender tests/stubs til PATH slik at tester kjorer stub-binaerer
+# for pg_isready, pg_dump, gpg og sleep i stedet for ekte verktoy.
+# Kalles fra setup() i .bats-filer som trenger stubs.
+setup_stubs() {
+    export PATH="${SAFEKEEPER_ROOT}/tests/stubs:${PATH}"
+}

--- a/tests/run_backup.bats
+++ b/tests/run_backup.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+#
+# Tester for run_backup happy path i backup-entrypoint.sh.
+# Bruker stubs for pg_isready/pg_dump/gpg slik at testene kjorer uten
+# ekte database eller GPG-nokkel.
+
+load 'helpers/common'
+
+setup() {
+    setup_stubs
+    BACKUP_DIR="$(mktemp -d)"
+    BACKUP_SUCCESS_FILE="$(mktemp -u)"
+    export BACKUP_DIR BACKUP_SUCCESS_FILE
+
+    export PROJECT_NAME=testprosjekt
+    export DB_PASSWORD=hemmelig
+    export BACKUP_ENCRYPTION_KEY=testnokkel123
+    unset HETZNER_HOST HETZNER_USER FILES_DIR
+    unset STUB_GPG_FAIL STUB_PGDUMP_FAIL STUB_PGISREADY_FAIL
+}
+
+teardown() {
+    rm -rf "$BACKUP_DIR"
+    rm -f "$BACKUP_SUCCESS_FILE"
+}
+
+@test "run_backup oppretter kryptert backup-fil i BACKUP_DIR" {
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -eq 0 ]
+
+    local files
+    files=$(find "$BACKUP_DIR" -maxdepth 1 -name "testprosjekt_*.sql.gz.gpg" | wc -l)
+    [ "$files" -eq 1 ]
+}
+
+@test "run_backup genererer .sha256-checksum-fil" {
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -eq 0 ]
+
+    local checksums
+    checksums=$(find "$BACKUP_DIR" -maxdepth 1 -name "testprosjekt_*.sql.gz.gpg.sha256" | wc -l)
+    [ "$checksums" -eq 1 ]
+}
+
+@test "run_backup skriver timestamp til BACKUP_SUCCESS_FILE" {
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -eq 0 ]
+
+    [ -f "$BACKUP_SUCCESS_FILE" ]
+    local ts
+    ts=$(cat "$BACKUP_SUCCESS_FILE")
+    [[ "$ts" =~ ^[0-9]+$ ]]
+}
+
+@test "backup-fil og checksum har chmod 600" {
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -eq 0 ]
+
+    local backup_file
+    backup_file=$(find "$BACKUP_DIR" -maxdepth 1 -name "testprosjekt_*.sql.gz.gpg" | head -1)
+    [ -n "$backup_file" ]
+
+    local perms
+    perms=$(stat -c '%a' "$backup_file")
+    [ "$perms" = "600" ]
+
+    perms=$(stat -c '%a' "${backup_file}.sha256")
+    [ "$perms" = "600" ]
+}
+
+@test "run_backup feiler hvis gpg-kryptering feiler (STUB_GPG_FAIL=1)" {
+    export STUB_GPG_FAIL=1
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -ne 0 ]
+
+    local files
+    files=$(find "$BACKUP_DIR" -maxdepth 1 -name "testprosjekt_*.sql.gz.gpg.sha256" | wc -l)
+    [ "$files" -eq 0 ]
+}

--- a/tests/stubs/gpg
+++ b/tests/stubs/gpg
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Stub for gpg. Pipe stdin direkte til stdout — fungerer for baade
+# --symmetric (krypter) og --decrypt siden ekte gzip ligger i pipelinen.
+# Returnerer 1 hvis STUB_GPG_FAIL=1.
+#
+# Lukker fd 3 eksplisitt for aa unngaa at process substitution
+# (--passphrase-fd 3 3< <(printf ...)) henger paa blokkert pipe.
+
+# Lukk fd 3 hvis den er aapen
+exec 3<&- 2>/dev/null || true
+
+[[ "${STUB_GPG_FAIL:-0}" == "1" ]] && exit 1
+
+# Passthrough: stdin -> stdout
+cat

--- a/tests/stubs/pg_dump
+++ b/tests/stubs/pg_dump
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Stub for pg_dump. Ignorer alle argumenter (inkl. PGPASSFILE).
+# Skriver gyldig SQL-tekst til stdout slik at gzip downstream kan komprimere.
+# Returnerer 1 hvis STUB_PGDUMP_FAIL=1.
+[[ "${STUB_PGDUMP_FAIL:-0}" == "1" ]] && exit 1
+printf -- '-- stub pg_dump dump\nCREATE TABLE test (id INT);\nINSERT INTO test VALUES (1);\n'
+exit 0

--- a/tests/stubs/pg_isready
+++ b/tests/stubs/pg_isready
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Stub for pg_isready. Ignorer alle argumenter.
+# Returnerer 1 hvis STUB_PGISREADY_FAIL=1, ellers 0.
+[[ "${STUB_PGISREADY_FAIL:-0}" == "1" ]] && exit 1
+exit 0

--- a/tests/stubs/sleep
+++ b/tests/stubs/sleep
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Stub for sleep. Returnerer umiddelbart for aa unngaa heng i
+# pg_isready-until-loop ved fail-scenarier i tester.
+exit 0


### PR DESCRIPTION
Fixes #7.

## Summary
- Legger til stub-binaerer for `pg_isready`, `pg_dump`, `gpg` og `sleep` i `tests/stubs/`
- Stoetter scenariovariasjon via `STUB_*_FAIL` miljoevariabler
- Utvider `tests/helpers/common.bash` med `setup_stubs()` som prepender stubs til PATH
- Introduserer `BACKUP_SUCCESS_FILE` env-var (default `/tmp/last-backup-success`) for testisolasjon
- Ny `tests/run_backup.bats` med 5 happy-path-tester (opprettelse av `.sql.gz.gpg`, `.sha256`, timestamp-fil, chmod 600, og fail-scenario)

## Test plan
- [x] `bats tests/` — alle 9 tester groenne lokalt
- [x] CI groent (ShellCheck + Hadolint + Docker Build)