### PR TITLE
Fix #8: BATS tests for restore.sh + Hetzner retry

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -30,9 +30,14 @@ tests/
     pg_isready               # Stub for PostgreSQL-helsesjekk
     pg_dump                  # Stub som skriver dummy-SQL til stdout
     gpg                      # Stub som pipe-through stdin (virker for --symmetric og --decrypt)
+    psql                     # Stub som konsumerer stdin (for restore-tester)
+    scp                      # Stub med STUB_SCP_FAIL for Hetzner-retry-tester
+    ssh                      # Stub med STUB_SSH_FAIL, returnerer tom stdout
     sleep                    # Stub som returnerer umiddelbart
   check_requirements.bats    # Tester for manglende miljøvariabler
   run_backup.bats            # Tester for happy-path backup-flyt
+  restore.bats               # Tester for restore.sh (checksum, krav om nøkkel)
+  hetzner_retry.bats         # Tester for upload_with_retry (3 forsøk, feilmelding)
 ```
 
 ## Stubs og scenariovariasjon
@@ -44,7 +49,10 @@ Stub-binærene i `tests/stubs/` prependes til `PATH` via `setup_stubs()` i `help
 | `STUB_GPG_FAIL=1` | `gpg` returnerer 1 |
 | `STUB_PGDUMP_FAIL=1` | `pg_dump` returnerer 1 |
 | `STUB_PGISREADY_FAIL=1` | `pg_isready` returnerer 1 |
+| `STUB_SCP_FAIL=1` | `scp` returnerer 1 (brukt i Hetzner-retry-tester) |
+| `STUB_SSH_FAIL=1` | `ssh` returnerer 1 |
+| `STUB_PSQL_FAIL=1` | `psql` returnerer 1 |
 
 For testisolasjon kan `BACKUP_SUCCESS_FILE` settes til en mktemp-sti i stedet for den hardkodede `/tmp/last-backup-success`.
 
-Flere testfiler for `restore.sh` og Hetzner-retry-logikk, samt CI-integrasjon, legges til i oppfølgende issues (se #4).
+`hetzner_retry.bats` sourcer `backup-entrypoint.sh` som bibliotek (main-kallet strippes bort) slik at `upload_with_retry` kan kalles direkte uten aa kjore en full backup-flyt.

--- a/tests/hetzner_retry.bats
+++ b/tests/hetzner_retry.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+#
+# Tester for upload_with_retry i backup-entrypoint.sh.
+# Verifiserer at opplasting forsoeker 3 ganger ved vedvarende scp-feil
+# og logger korrekt feilmelding naar alle forsoek slar feil.
+#
+# backup-entrypoint.sh sources som bibliotek (main-kallet strippes bort)
+# slik at upload_with_retry kan kalles direkte uten aa kjore en full
+# backup-flyt.
+
+load 'helpers/common'
+
+setup() {
+    setup_stubs
+    BACKUP_DIR="$(mktemp -d)"
+    export BACKUP_DIR
+
+    export PROJECT_NAME=testprosjekt
+    export DB_PASSWORD=hemmelig
+    export BACKUP_ENCRYPTION_KEY=testnokkel
+    export HETZNER_HOST=hetzner.example
+    export HETZNER_USER=u12345
+
+    unset STUB_SCP_FAIL STUB_SSH_FAIL
+}
+
+teardown() {
+    rm -rf "$BACKUP_DIR"
+}
+
+# Laster backup-entrypoint.sh som bibliotek uten aa kjore main.
+# Populerer deretter SSH_KEY saa hetzner_configured returnerer sant.
+load_backup_lib() {
+    local stripped
+    stripped=$(sed 's|^main "\$@".*$|:|' "$SAFEKEEPER_ROOT/backup-entrypoint.sh")
+    eval "$stripped"
+    echo "dummy-ssh-key" > "$SSH_KEY"
+}
+
+@test "upload_with_retry prover 3 ganger ved vedvarende scp-feil" {
+    export STUB_SCP_FAIL=1
+    load_backup_lib
+
+    local dummy="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
+    echo "content" > "$dummy"
+
+    run upload_with_retry "$dummy"
+    [[ "$output" == *"forsok 1/3"* ]]
+    [[ "$output" == *"forsok 2/3"* ]]
+}
+
+@test "upload_with_retry logger 'etter 3 forsok' ved total feil" {
+    export STUB_SCP_FAIL=1
+    load_backup_lib
+
+    local dummy="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
+    echo "content" > "$dummy"
+
+    run upload_with_retry "$dummy"
+    [[ "$output" == *"Hetzner-opplasting feilet etter 3 forsok"* ]]
+}

--- a/tests/restore.bats
+++ b/tests/restore.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+#
+# Tester for restore.sh.
+# Dekker checksum-verifisering og krav om BACKUP_ENCRYPTION_KEY
+# for .gpg-filer. Bruker psql-stub for aa unngaa ekte database.
+
+load 'helpers/common'
+
+setup() {
+    setup_stubs
+    BACKUP_DIR="$(mktemp -d)"
+    export BACKUP_DIR
+
+    export PROJECT_NAME=testprosjekt
+    export DB_PASSWORD=hemmelig
+    unset BACKUP_ENCRYPTION_KEY
+}
+
+teardown() {
+    rm -rf "$BACKUP_DIR"
+}
+
+@test "restore.sh feiler hvis backup-fil ikke finnes" {
+    export BACKUP_ENCRYPTION_KEY=testnokkel
+    run bash "$SAFEKEEPER_ROOT/restore.sh" "$BACKUP_DIR/finnes-ikke.sql.gz.gpg"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Backup-fil finnes ikke"* ]]
+}
+
+@test "restore.sh feiler hvis BACKUP_ENCRYPTION_KEY mangler for .gpg-fil" {
+    local backup_file="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
+    echo "dummy kryptert innhold" > "$backup_file"
+
+    unset BACKUP_ENCRYPTION_KEY
+    run bash "$SAFEKEEPER_ROOT/restore.sh" "$backup_file"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"BACKUP_ENCRYPTION_KEY"* ]]
+}
+
+@test "restore.sh feiler ved checksum-mismatch" {
+    export BACKUP_ENCRYPTION_KEY=testnokkel
+    local backup_file="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
+    echo "faktisk innhold" > "$backup_file"
+    # Skriv en feil checksum til .sha256-filen
+    echo "0000000000000000000000000000000000000000000000000000000000000000  $backup_file" \
+        > "${backup_file}.sha256"
+
+    run bash "$SAFEKEEPER_ROOT/restore.sh" "$backup_file"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Checksum-verifisering feilet"* ]]
+}

--- a/tests/stubs/psql
+++ b/tests/stubs/psql
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Stub for psql. Konsumerer stdin slik at pipelines ikke henger.
+# Ignorer alle argumenter (inkludert PGPASSFILE og --single-transaction).
+# Returnerer 1 hvis STUB_PSQL_FAIL=1.
+[[ "${STUB_PSQL_FAIL:-0}" == "1" ]] && { cat > /dev/null; exit 1; }
+cat > /dev/null
+exit 0

--- a/tests/stubs/scp
+++ b/tests/stubs/scp
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Stub for scp. Ignorer alle argumenter.
+# Returnerer 1 hvis STUB_SCP_FAIL=1, ellers 0.
+[[ "${STUB_SCP_FAIL:-0}" == "1" ]] && exit 1
+exit 0

--- a/tests/stubs/ssh
+++ b/tests/stubs/ssh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Stub for ssh. Ignorer alle argumenter og returnerer 0 med tom stdout.
+# Dette treffer mkdir-loopen i upload_to_hetzner (som ignorerer feil),
+# samt sha256sum-verifiseringen (tom stdout -> remote_sha256 blir tom og
+# funksjonen logger advarsel, men returnerer 0).
+# Returnerer 1 hvis STUB_SSH_FAIL=1.
+[[ "${STUB_SSH_FAIL:-0}" == "1" ]] && exit 1
+exit 0


### PR DESCRIPTION
Fixes #8

## Summary
- New stubs: `scp`, `ssh`, `psql` with `STUB_SCP_FAIL`, `STUB_SSH_FAIL`, `STUB_PSQL_FAIL`
- `tests/restore.bats`: missing backup file, missing `BACKUP_ENCRYPTION_KEY` for `.gpg`, checksum-mismatch
- `tests/hetzner_retry.bats`: `upload_with_retry` attempts 3 times on persistent `scp` failure and logs `"Hetzner-opplasting feilet etter 3 forsok"` on total failure
- `hetzner_retry.bats` sources `backup-entrypoint.sh` as a library (main call stripped) to call `upload_with_retry` directly

## Test plan
- [x] `./tests/run.sh` — all 14 tests pass locally
- [x] CI green (ShellCheck, Hadolint, Docker Build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)