### PR TITLE
Fix #9: add BATS job to CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: hadolint/hadolint-action@v3.1.0
 
+  bats:
+    name: BATS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bats-core/bats-action@3.0.0
+      - name: Run BATS tests
+        run: bats tests/
+
   docker-build:
     name: Docker Build
     runs-on: ubuntu-latest
-    needs: [shellcheck, hadolint]
+    needs: [shellcheck, hadolint, bats]
     steps:
       - uses: actions/checkout@v4
       - uses: docker/build-push-action@v6


### PR DESCRIPTION
Fixes #9

## Summary
- Legger til ny `bats`-jobb i `.github/workflows/build.yml` som bruker `bats-core/bats-action@3.0.0` og kjoerer `bats tests/` paa Ubuntu-runner
- Oppdaterer `docker-build`-jobben til aa avhenge av `[shellcheck, hadolint, bats]` slik at feilende tester blokkerer image-build

## Test plan
- [x] Alle 14 BATS-tester kjoerer lokalt
- [x] CI-kjoering paa branch bekrefter at `bats`-jobben passerer og at `docker-build` venter paa den