### PR TITLE
feat: restore.sh støtte for fil-backups (.tar.gz.gpg) (#17)

### DIFF
--- a/restore.sh
+++ b/restore.sh
@@ -18,6 +18,7 @@ DB_PASSWORD="${DB_PASSWORD:-}"
 
 BACKUP_DIR="${BACKUP_DIR:-/backups}"
 BACKUP_ENCRYPTION_KEY="${BACKUP_ENCRYPTION_KEY:-}"
+FILES_DIR="${FILES_DIR:-}"
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"; }
 error() { log "FEIL: $1" >&2; exit 1; }
@@ -31,27 +32,68 @@ setup_pgpass() {
 }
 
 cleanup_pgpass() {
-    [[ -n "${PGPASS_FILE:-}" ]] && rm -f "$PGPASS_FILE"
+    if [[ -n "${PGPASS_FILE:-}" ]]; then
+        rm -f "$PGPASS_FILE"
+    fi
 }
 trap cleanup_pgpass EXIT
 
 usage() {
     echo "Bruk:"
-    echo "  $0 <backup_file>    Gjenopprett fra lokal fil"
-    echo "  $0 --list           List tilgjengelige backups"
+    echo "  $0 <backup_file>                    Gjenopprett database-backup"
+    echo "  $0 <fil.tar.gz.gpg> [maalmappe]     Gjenopprett fil-backup (default: gjeldende mappe)"
+    echo "  $0 --list                            List tilgjengelige database-backups"
+    echo "  $0 --list-files                      List tilgjengelige fil-backups"
     echo ""
     echo "Eksempler:"
     echo "  $0 /backups/${PROJECT_NAME}_20260218_030000.sql.gz.gpg"
+    echo "  $0 /backups/${PROJECT_NAME}_files_20260218_030000.tar.gz.gpg /var/data"
     echo ""
     echo "Miljovariabler:"
     echo "  BACKUP_ENCRYPTION_KEY    Dekrypteringsnokkel (pakrevd for .gpg-filer)"
-    echo "  DB_PASSWORD              Database-passord (pakrevd)"
+    echo "  DB_PASSWORD              Database-passord (pakrevd for database-restore)"
     exit 1
 }
 
 list_backups() {
     log "Tilgjengelige backups i ${BACKUP_DIR} (${PROJECT_NAME}):"
     ls -lh "${BACKUP_DIR}/${PROJECT_NAME}"_*.sql.gz* 2>/dev/null || log "Ingen backups funnet."
+}
+
+list_files() {
+    log "Tilgjengelige fil-backups i ${BACKUP_DIR} (${PROJECT_NAME}):"
+    ls -lh "${BACKUP_DIR}/${PROJECT_NAME}"_files_*.tar.gz* 2>/dev/null || log "Ingen fil-backups funnet."
+}
+
+verify_checksum() {
+    local backup_file="$1"
+    if [[ -f "${backup_file}.sha256" ]]; then
+        log "Verifiserer checksum..."
+        if sha256sum -c "${backup_file}.sha256" > /dev/null 2>&1; then
+            log "Checksum verifisert OK"
+        else
+            error "Checksum-verifisering feilet! Backup-filen kan vaere korrupt."
+        fi
+    fi
+}
+
+restore_files() {
+    local backup_file="$1"
+    local target_dir="${2:-${FILES_DIR:-.}}"
+
+    [[ ! -f "$backup_file" ]] && error "Backup-fil finnes ikke: $backup_file"
+
+    verify_checksum "$backup_file"
+
+    [[ -z "$BACKUP_ENCRYPTION_KEY" ]] && error "BACKUP_ENCRYPTION_KEY ma vaere satt for a dekryptere .gpg-filer"
+
+    log "Gjenoppretter filer til: $target_dir"
+    gpg --batch --yes --decrypt \
+        --passphrase-fd 3 3< <(printf '%s' "$BACKUP_ENCRYPTION_KEY") \
+        < "$backup_file" \
+        | tar xzf - -C "$target_dir"
+
+    log "Fil-gjenoppretting fullfort!"
 }
 
 restore_backup() {
@@ -62,15 +104,7 @@ restore_backup() {
 
     setup_pgpass
 
-    # Verifiser checksum hvis tilgjengelig
-    if [[ -f "${backup_file}.sha256" ]]; then
-        log "Verifiserer checksum..."
-        if sha256sum -c "${backup_file}.sha256" > /dev/null 2>&1; then
-            log "Checksum verifisert OK"
-        else
-            error "Checksum-verifisering feilet! Backup-filen kan vaere korrupt."
-        fi
-    fi
+    verify_checksum "$backup_file"
 
     log "Gjenoppretter fra: $backup_file"
 
@@ -99,5 +133,12 @@ restore_backup() {
 case "$1" in
     --help|-h) usage ;;
     --list) list_backups ;;
-    *) restore_backup "$1" ;;
+    --list-files) list_files ;;
+    *)
+        if [[ "$1" == *.tar.gz.gpg ]]; then
+            restore_files "$1" "${2:-}"
+        else
+            restore_backup "$1"
+        fi
+        ;;
 esac

--- a/tests/restore.bats
+++ b/tests/restore.bats
@@ -49,3 +49,61 @@ teardown() {
     [ "$status" -ne 0 ]
     [[ "$output" == *"Checksum-verifisering feilet"* ]]
 }
+
+# --- Fil-backup (.tar.gz.gpg) ---
+
+@test "--list-files viser tilgjengelige fil-backups" {
+    touch "$BACKUP_DIR/testprosjekt_files_20260101_120000.tar.gz.gpg"
+    run bash "$SAFEKEEPER_ROOT/restore.sh" --list-files
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"testprosjekt_files_20260101_120000.tar.gz.gpg"* ]]
+}
+
+@test "--list-files melder ingen backups hvis ingen finnes" {
+    run bash "$SAFEKEEPER_ROOT/restore.sh" --list-files
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Ingen fil-backups funnet"* ]]
+}
+
+@test "restore.sh feiler hvis fil-backup ikke finnes" {
+    export BACKUP_ENCRYPTION_KEY=testnokkel
+    run bash "$SAFEKEEPER_ROOT/restore.sh" "$BACKUP_DIR/finnes-ikke.tar.gz.gpg"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Backup-fil finnes ikke"* ]]
+}
+
+@test "restore.sh feiler hvis BACKUP_ENCRYPTION_KEY mangler for .tar.gz.gpg" {
+    local backup_file="$BACKUP_DIR/testprosjekt_files_20260101_120000.tar.gz.gpg"
+    echo "dummy" > "$backup_file"
+    unset BACKUP_ENCRYPTION_KEY
+    run bash "$SAFEKEEPER_ROOT/restore.sh" "$backup_file"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"BACKUP_ENCRYPTION_KEY"* ]]
+}
+
+@test "restore.sh feiler ved checksum-mismatch for fil-backup" {
+    export BACKUP_ENCRYPTION_KEY=testnokkel
+    local backup_file="$BACKUP_DIR/testprosjekt_files_20260101_120000.tar.gz.gpg"
+    echo "faktisk innhold" > "$backup_file"
+    echo "0000000000000000000000000000000000000000000000000000000000000000  $backup_file" \
+        > "${backup_file}.sha256"
+    run bash "$SAFEKEEPER_ROOT/restore.sh" "$backup_file"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Checksum-verifisering feilet"* ]]
+}
+
+@test "restore.sh gjenoppretter fil-backup til maalmappe" {
+    export BACKUP_ENCRYPTION_KEY=testnokkel
+    local target_dir
+    target_dir=$(mktemp -d)
+    local src_dir
+    src_dir=$(mktemp -d)
+    echo "testinnhold" > "$src_dir/testfil.txt"
+    local backup_file="$BACKUP_DIR/testprosjekt_files_20260101_120000.tar.gz.gpg"
+    # gpg-stubben passerer gjennom, så vi lager en ekte tar.gz
+    tar czf "$backup_file" -C "$(dirname "$src_dir")" "$(basename "$src_dir")"
+    run bash "$SAFEKEEPER_ROOT/restore.sh" "$backup_file" "$target_dir"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Fil-gjenoppretting fullfort"* ]]
+    rm -rf "$src_dir" "$target_dir"
+}


### PR DESCRIPTION
Fixes #17

## Endringer

- `--list-files` flag for å liste tilgjengelige fil-backups (`.tar.gz.gpg`)
- `restore_files()` funksjon: checksum → dekrypter (GPG) → ekstraher (tar) til mål-mappe
- Routing: `.tar.gz.gpg` sendes til `restore_files()`, DB-backups til `restore_backup()`
- `verify_checksum()` ekstrahert som felles hjelper
- Bugfix: `cleanup_pgpass()` via `trap EXIT` overskrev exit-kode (returnerte 1 når PGPASS_FILE var tom)
- `usage()` oppdatert med nye flagg og eksempler

## Nye BATS-tester (6 stk)

- `--list-files` viser fil-backups
- `--list-files` melder ingen backups hvis ingen finnes
- Feiler hvis fil-backup ikke finnes
- Feiler hvis BACKUP_ENCRYPTION_KEY mangler for `.tar.gz.gpg`
- Feiler ved checksum-mismatch
- Gjenoppretter fil-backup til målmappe