### PR TITLE
fix: validate target directory in restore_files

### DIFF
--- a/restore.sh
+++ b/restore.sh
@@ -81,6 +81,9 @@ restore_files() {
     local backup_file="$1"
     local target_dir="${2:-${FILES_DIR:-.}}"
 
+    target_dir=$(cd "$target_dir" 2>/dev/null && pwd) \
+        || error "Maalmappe finnes ikke eller er ikke en katalog: ${2:-${FILES_DIR:-.}}"
+
     [[ ! -f "$backup_file" ]] && error "Backup-fil finnes ikke: $backup_file"
 
     verify_checksum "$backup_file"

--- a/tests/restore.bats
+++ b/tests/restore.bats
@@ -92,6 +92,15 @@ teardown() {
     [[ "$output" == *"Checksum-verifisering feilet"* ]]
 }
 
+@test "restore.sh feiler hvis maalmappe ikke finnes" {
+    export BACKUP_ENCRYPTION_KEY=testnokkel
+    local backup_file="$BACKUP_DIR/testprosjekt_files_20260101_120000.tar.gz.gpg"
+    echo "dummy" > "$backup_file"
+    run bash "$SAFEKEEPER_ROOT/restore.sh" "$backup_file" "/finnes/ikke/2026"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Maalmappe finnes ikke"* ]]
+}
+
 @test "restore.sh gjenoppretter fil-backup til maalmappe" {
     export BACKUP_ENCRYPTION_KEY=testnokkel
     local target_dir


### PR DESCRIPTION
Follow-up security fix from QA review of #18 (issue #17).

`restore_files()` now resolves the target directory to an absolute path via `cd && pwd` before extracting. Fails early with a clear error if the directory does not exist, preventing use of non-existent or path-traversal targets.

Adds one new BATS test: `restore.sh feiler hvis maalmappe ikke finnes`.