### PR TITLE
fix: use passphrase-fd in encryption.bats list-packets call

### DIFF
--- a/tests/encryption.bats
+++ b/tests/encryption.bats
@@ -111,7 +111,7 @@ setup_stubs_without_gpg() {
     local packets
     packets=$(gpg --batch --list-packets \
         --pinentry-mode loopback \
-        --passphrase "$BACKUP_ENCRYPTION_KEY" \
+        --passphrase-fd 3 3< <(printf '%s' "$BACKUP_ENCRYPTION_KEY") \
         < "$backup_file" 2>&1)
     [[ "$packets" =~ cipher\ 9 ]] || [[ "$packets" =~ AES256 ]]
 }


### PR DESCRIPTION
## Summary

QA-review av #20 (PR #23) flagget at `gpg --list-packets`-kallet i `tests/encryption.bats` brukte `--passphrase` (argv) istedenfor `--passphrase-fd 3`. Endrer til fd-metoden for konsistens med resten av kodebasen og for aa unngaa at testnoekkelen lekker i prosesslisten.

## Test plan
- [x] `bats tests/encryption.bats` passerer alle 5 tester
- [ ] CI gronn

🤖 Generated with [Claude Code](https://claude.com/claude-code)