### PR TITLE
Fix #22: BATS cron setup tests + fix env grep pattern

### DIFF
--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -24,6 +24,10 @@ DB_USER="${DB_USER:-${PROJECT_NAME}}"
 
 BACKUP_ENCRYPTION_KEY="${BACKUP_ENCRYPTION_KEY:-}"
 
+# Interne fil-stier (kan overstyres i tester via env-variabler)
+SAFEKEEPER_ENV_FILE="${SAFEKEEPER_ENV_FILE:-/etc/safekeeper.env}"
+CRONTAB_FILE="${CRONTAB_FILE:-/etc/crontabs/root}"
+
 # Fil-backup (valgfritt)
 FILES_DIR="${FILES_DIR:-}"
 
@@ -282,9 +286,9 @@ main() {
 
     log "Setter opp daglig backup: $BACKUP_SCHEDULE"
     # Eksporter miljovariabler til fil for cron (BusyBox crond arver ikke Docker env)
-    env | grep -E '^(PROJECT_NAME|DB_|BACKUP_|FILES_DIR|HETZNER_|TZ)=' | sed 's/^\(.*\)$/export \1/' > /etc/safekeeper.env
-    chmod 600 /etc/safekeeper.env
-    echo "$BACKUP_SCHEDULE . /etc/safekeeper.env; /usr/local/bin/backup-entrypoint.sh backup >> /var/log/backup.log 2>&1" > /etc/crontabs/root
+    env | grep -E '^(PROJECT_NAME|DB_|BACKUP_|FILES_DIR|HETZNER_|TZ)[^=]*=' | sed 's/^\(.*\)$/export \1/' > "$SAFEKEEPER_ENV_FILE"
+    chmod 600 "$SAFEKEEPER_ENV_FILE"
+    echo "$BACKUP_SCHEDULE . $SAFEKEEPER_ENV_FILE; /usr/local/bin/backup-entrypoint.sh backup >> /var/log/backup.log 2>&1" > "$CRONTAB_FILE"
 
     log "Starter cron daemon..."
     exec crond -f -l 2

--- a/tests/cron.bats
+++ b/tests/cron.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+#
+# Tester for cron-oppsett i main() (uten backup-argument) i backup-entrypoint.sh.
+# Verifiserer at /etc/safekeeper.env og /etc/crontabs/root skrives korrekt.
+# Bruker stubs for pg_isready/pg_dump/gpg/crond.
+
+load 'helpers/common'
+
+setup() {
+    setup_stubs
+
+    BACKUP_DIR="$(mktemp -d)"
+    BACKUP_SUCCESS_FILE="$(mktemp -u)"
+    SAFEKEEPER_ENV_FILE="$(mktemp -u)"
+    CRONTAB_FILE="$(mktemp -u)"
+    export BACKUP_DIR BACKUP_SUCCESS_FILE SAFEKEEPER_ENV_FILE CRONTAB_FILE
+
+    export PROJECT_NAME=testprosjekt
+    export DB_PASSWORD=hemmelig
+    export BACKUP_ENCRYPTION_KEY=testnokkel123
+    unset HETZNER_HOST HETZNER_USER FILES_DIR
+    unset STUB_GPG_FAIL STUB_PGDUMP_FAIL STUB_PGISREADY_FAIL
+}
+
+teardown() {
+    rm -rf "$BACKUP_DIR"
+    rm -f "$BACKUP_SUCCESS_FILE" "$SAFEKEEPER_ENV_FILE" "$CRONTAB_FILE"
+}
+
+@test "BACKUP_SCHEDULE lagres i crontab-fil" {
+    export BACKUP_SCHEDULE="0 3 * * *"
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh"
+    [ "$status" -eq 0 ]
+
+    [ -f "$CRONTAB_FILE" ]
+    grep -q "0 3 \* \* \*" "$CRONTAB_FILE"
+}
+
+@test "standardverdi '0 5 * * *' brukes i crontab hvis BACKUP_SCHEDULE ikke er satt" {
+    unset BACKUP_SCHEDULE
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh"
+    [ "$status" -eq 0 ]
+
+    [ -f "$CRONTAB_FILE" ]
+    grep -q "0 5 \* \* \*" "$CRONTAB_FILE"
+}
+
+@test "safekeeper.env opprettes med eksporterte variabler" {
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh"
+    [ "$status" -eq 0 ]
+
+    [ -f "$SAFEKEEPER_ENV_FILE" ]
+    grep -q "export PROJECT_NAME=" "$SAFEKEEPER_ENV_FILE"
+    grep -q "export DB_PASSWORD=" "$SAFEKEEPER_ENV_FILE"
+    grep -q "export BACKUP_ENCRYPTION_KEY=" "$SAFEKEEPER_ENV_FILE"
+}
+
+@test "safekeeper.env har chmod 600" {
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh"
+    [ "$status" -eq 0 ]
+
+    [ -f "$SAFEKEEPER_ENV_FILE" ]
+    local perms
+    perms=$(stat -c '%a' "$SAFEKEEPER_ENV_FILE")
+    [ "$perms" = "600" ]
+}

--- a/tests/stubs/crond
+++ b/tests/stubs/crond
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Stub for crond. Avslutter umiddelbart slik at tester kan inspisere
+# /etc/crontabs/root og /etc/safekeeper.env etter cron-oppsett.
+exit 0


### PR DESCRIPTION
Fixes #22

## Endringer

- `tests/cron.bats` — 4 BATS-tester for cron-oppstartsflyten i `main()`:
  - BACKUP_SCHEDULE lagres i crontab-fil
  - Standardverdi `0 5 * * *` brukes når BACKUP_SCHEDULE ikke er satt
  - `safekeeper.env` opprettes med eksporterte variabler (PROJECT_NAME, DB_*, BACKUP_*)
  - `safekeeper.env` har chmod 600

- `tests/stubs/crond` — ny stub som avslutter umiddelbart (exit 0) slik at tester kan inspisere de genererte filene

- `backup-entrypoint.sh` — to endringer:
  1. Støtter `SAFEKEEPER_ENV_FILE` og `CRONTAB_FILE` env-variabler (standardverdier: `/etc/safekeeper.env` og `/etc/crontabs/root`)
  2. Fikser grep-mønster: `'^(...|DB_|...)='` matchet bare eksakt `DB_=` — endret til `'^(...|DB_|...)[^=]*='` slik at `DB_PASSWORD`, `DB_HOST`, `BACKUP_DIR` etc. skrives korrekt til cron env-filen