### PR TITLE
ci: include revert/* in auto-merge prefix list

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -41,7 +41,8 @@ jobs:
         startsWith(github.head_ref, 'test/') ||
         startsWith(github.head_ref, 'perf/') ||
         startsWith(github.head_ref, 'style/') ||
-        startsWith(github.head_ref, 'build/')
+        startsWith(github.head_ref, 'build/') ||
+        startsWith(github.head_ref, 'revert/')
       )
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
Legg til `startsWith(github.head_ref, 'revert/')` i prefix-listen for native auto-merge. Revert-PR-er er rutinemessig vedlikehold på linje med `fix/`/`feat/`/`chore/`/etc.

## Bakgrunn
2026-04-27 merget jeg grunnmur-frontend#65 (revert av #64 etter at en .dockerignore-endring overskøt). PR-en hadde alle CI grønne, men auto-merge.yml hoppet over den fordi `revert/`-prefiks ikke var i listen. Måtte merge manuelt.

## Test plan
- [ ] CI grønn på denne PR-en
- [ ] Neste revert-PR (`revert/*`) skal trigge enable-auto-merge automatisk

🤖 Generated with [Claude Code](https://claude.com/claude-code)