### PR TITLE
chore: legg til github-actions i Dependabot (refs #29)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,17 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/Oslo"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "deps(actions)"


### PR DESCRIPTION
Legger til `github-actions` som `package-ecosystem` i eksisterende `.github/dependabot.yml`.

## Hva dette gjør

Dependabot vil nå automatisk opprette ukentlige PRer når nye versjoner av disse actions slippes:
- `ludeeus/action-shellcheck`
- `hadolint/hadolint-action`
- `bats-core/bats-action`
- `docker/build-push-action`
- `actions/checkout`

## Hva dette IKKE gjør

SHA-pinning av `.github/workflows/build.yml` er ikke inkludert her — det krever manuell redigering av workflow-filen. SHA-er for manuell pinning er dokumentert i #29:

```yaml
- uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # 2.0.0
- uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf  # v3.1.0
- uses: bats-core/bats-action@2104b40bb7b6c2d5110b23a26b0bf265ab8027db   # 3.0.0
- uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
- uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5        # v4
```

refs #29