### PR TITLE
Fix #28: pg_isready-loop får konfigurerbar timeout via DB_WAIT_TIMEOUT

### DIFF
--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -23,6 +23,7 @@ DB_NAME="${DB_NAME:-${PROJECT_NAME}}"
 DB_USER="${DB_USER:-${PROJECT_NAME}}"
 
 BACKUP_ENCRYPTION_KEY="${BACKUP_ENCRYPTION_KEY:-}"
+DB_WAIT_TIMEOUT="${DB_WAIT_TIMEOUT:-60}"
 
 # Interne fil-stier (kan overstyres i tester via env-variabler)
 SAFEKEEPER_ENV_FILE="${SAFEKEEPER_ENV_FILE:-/etc/safekeeper.env}"
@@ -155,8 +156,14 @@ run_backup() {
 
     log "Starter backup..."
 
+    local db_wait_attempts=0
+    local db_wait_max=$(( DB_WAIT_TIMEOUT / 2 ))
     until pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" > /dev/null 2>&1; do
-        log "Venter pa database..."
+        db_wait_attempts=$(( db_wait_attempts + 1 ))
+        if [[ $db_wait_attempts -ge $db_wait_max ]]; then
+            error "Database ikke tilgjengelig etter ${DB_WAIT_TIMEOUT} sekunder (${db_wait_attempts} forsok)"
+        fi
+        log "Venter pa database (forsok ${db_wait_attempts}/${db_wait_max})..."
         sleep 2
     done
 

--- a/tests/run_backup.bats
+++ b/tests/run_backup.bats
@@ -77,3 +77,19 @@ teardown() {
     files=$(find "$BACKUP_DIR" -maxdepth 1 -name "testprosjekt_*.sql.gz.gpg.sha256" | wc -l)
     [ "$files" -eq 0 ]
 }
+
+@test "run_backup feiler med feilmelding naar database aldri starter (DB_WAIT_TIMEOUT)" {
+    export STUB_PGISREADY_FAIL=always
+    export DB_WAIT_TIMEOUT=4
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"ikke tilgjengelig"* ]]
+}
+
+@test "run_backup logger forsoksteller mens den venter pa database" {
+    export STUB_PGISREADY_FAIL=always
+    export DB_WAIT_TIMEOUT=4
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"forsok"* ]]
+}

--- a/tests/stubs/pg_isready
+++ b/tests/stubs/pg_isready
@@ -1,5 +1,5 @@
 #!/bin/bash
 # Stub for pg_isready. Ignorer alle argumenter.
-# Returnerer 1 hvis STUB_PGISREADY_FAIL=1, ellers 0.
-[[ "${STUB_PGISREADY_FAIL:-0}" == "1" ]] && exit 1
+# STUB_PGISREADY_FAIL=1|always: returner 1 (feil), ellers 0 (ok).
+[[ "${STUB_PGISREADY_FAIL:-0}" == "1" || "${STUB_PGISREADY_FAIL:-0}" == "always" ]] && exit 1
 exit 0


### PR DESCRIPTION
Fixes #28

Legger til `DB_WAIT_TIMEOUT` (default 60s) slik at backup-containeren feiler med feilmelding istedenfor å blokkere evig dersom databasen ikke starter.

**Endringer:**
- `backup-entrypoint.sh`: Teller forsøk i pg_isready-loopen og feiler etter `DB_WAIT_TIMEOUT` sekunder. Logger forsøksnummer slik at ventetid er sporbar.
- `tests/stubs/pg_isready`: Støtter nå `STUB_PGISREADY_FAIL=always` for timeout-tester.
- `tests/run_backup.bats`: To nye tester — verifiserer non-zero exit med feilmelding og forsøksteller.