### PR TITLE
Fix #28 follow-up: rett off-by-one i DB_WAIT_TIMEOUT-loop

### DIFF
--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -160,11 +160,11 @@ run_backup() {
     local db_wait_max=$(( DB_WAIT_TIMEOUT / 2 ))
     until pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" > /dev/null 2>&1; do
         db_wait_attempts=$(( db_wait_attempts + 1 ))
+        log "Venter pa database (forsok ${db_wait_attempts}/${db_wait_max})..."
+        sleep 2
         if [[ $db_wait_attempts -ge $db_wait_max ]]; then
             error "Database ikke tilgjengelig etter ${DB_WAIT_TIMEOUT} sekunder (${db_wait_attempts} forsok)"
         fi
-        log "Venter pa database (forsok ${db_wait_attempts}/${db_wait_max})..."
-        sleep 2
     done
 
     log "Krypterer backup med GPG (AES256)..."

--- a/tests/run_backup.bats
+++ b/tests/run_backup.bats
@@ -78,18 +78,11 @@ teardown() {
     [ "$files" -eq 0 ]
 }
 
-@test "run_backup feiler med feilmelding naar database aldri starter (DB_WAIT_TIMEOUT)" {
+@test "run_backup feiler med feilmelding og forsoksteller naar database aldri starter (DB_WAIT_TIMEOUT)" {
     export STUB_PGISREADY_FAIL=always
     export DB_WAIT_TIMEOUT=4
     run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
     [ "$status" -ne 0 ]
     [[ "$output" == *"ikke tilgjengelig"* ]]
-}
-
-@test "run_backup logger forsoksteller mens den venter pa database" {
-    export STUB_PGISREADY_FAIL=always
-    export DB_WAIT_TIMEOUT=4
-    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
-    [ "$status" -ne 0 ]
     [[ "$output" == *"forsok"* ]]
 }


### PR DESCRIPTION
Follow-up til #38 basert på QA-review.

**Problem**: Feilmeldingen sa «etter 60 sekunder» men loopen sov kun 58 sekunder (sleep skjedde etter timeout-sjekken, så siste sleep ble aldri utført).

**Fiks**: Flytt `sleep 2` til før timeout-sjekken slik at faktisk ventetid matcher det rapporterte antallet sekunder.

**Rydding**: Slå sammen to identiske BATS-tester til én.