### PR TITLE
Fix #30: batch Hetzner-sletting til én SSH-kommando

### DIFF
--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -136,17 +136,23 @@ cleanup_hetzner() {
     cutoff_ts=$(date -d "-${BACKUP_RETENTION_DAYS} days" +%Y%m%d 2>/dev/null || date -v-"${BACKUP_RETENTION_DAYS}"d +%Y%m%d 2>/dev/null || echo "")
     [[ -z "$cutoff_ts" ]] && return 0
 
+    local files_to_delete=()
     # shellcheck disable=SC2086,SC2029
-    ssh ${SSH_OPTS} "${HETZNER_USER}@${HETZNER_HOST}" "ls ${HETZNER_BACKUP_PATH}" 2>/dev/null | while read -r remote_file; do
+    while read -r remote_file; do
         local file_date
         file_date=$(echo "$remote_file" | grep -oP "${PROJECT_NAME}_\K[0-9]{8}" || echo "")
         if [[ -n "$file_date" ]] && [[ "$file_date" < "$cutoff_ts" ]]; then
-            log "Sletter gammel offsite backup: $remote_file"
-            # shellcheck disable=SC2086,SC2029
-            ssh ${SSH_OPTS} "${HETZNER_USER}@${HETZNER_HOST}" \
-                "rm \"${HETZNER_BACKUP_PATH}/${remote_file}\"" 2>/dev/null || true
+            log "Markerer for sletting: $remote_file"
+            files_to_delete+=("${HETZNER_BACKUP_PATH}/${remote_file}")
         fi
-    done
+    done < <(ssh ${SSH_OPTS} "${HETZNER_USER}@${HETZNER_HOST}" "ls ${HETZNER_BACKUP_PATH}" 2>/dev/null)
+
+    if [[ ${#files_to_delete[@]} -gt 0 ]]; then
+        log "Sletter ${#files_to_delete[@]} gammel(e) offsite backup(s)..."
+        # shellcheck disable=SC2086,SC2029
+        ssh ${SSH_OPTS} "${HETZNER_USER}@${HETZNER_HOST}" \
+            "rm $(printf '"%s" ' "${files_to_delete[@]}")" 2>/dev/null || true
+    fi
 }
 
 run_backup() {

--- a/tests/hetzner_cleanup.bats
+++ b/tests/hetzner_cleanup.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+#
+# Tester for cleanup_hetzner() i backup-entrypoint.sh.
+# Verifiserer at sletting av gamle Hetzner-backups gjøres med én SSH rm-kommando
+# uansett antall filer (ikke N+1 SSH-tilkoblinger).
+
+load 'helpers/common'
+
+setup() {
+    setup_stubs
+    BACKUP_DIR="$(mktemp -d)"
+    export BACKUP_DIR
+
+    export PROJECT_NAME=testprosjekt
+    export DB_PASSWORD=hemmelig
+    export BACKUP_ENCRYPTION_KEY=testnokkel
+    export HETZNER_HOST=hetzner.example
+    export HETZNER_USER=u12345
+    export BACKUP_RETENTION_DAYS=30
+
+    STUB_SSH_CALL_LOG="$(mktemp)"
+    export STUB_SSH_CALL_LOG
+
+    unset STUB_SCP_FAIL STUB_SSH_FAIL STUB_SSH_LS_OUTPUT
+}
+
+teardown() {
+    rm -rf "$BACKUP_DIR"
+    rm -f "${STUB_SSH_CALL_LOG:-}"
+}
+
+# Laster backup-entrypoint.sh som bibliotek uten main og uten set -euo pipefail
+# (set -euo pipefail forstyrrer BATS sin feilhåndtering i testsuiten).
+load_backup_lib() {
+    local stripped
+    # Strip set -euo pipefail og trap cleanup EXIT — begge forstyrrer BATS sin feilhåndtering.
+    stripped=$(sed 's|^main "\$@".*$|:|; s|^set -euo pipefail.*$|:|; s|^trap cleanup EXIT.*$|:|' "$SAFEKEEPER_ROOT/backup-entrypoint.sh")
+    eval "$stripped"
+    echo "dummy-ssh-key" > "$SSH_KEY"
+}
+
+@test "cleanup_hetzner gjør maks 2 SSH-kall (ls + rm) for 3 gamle filer" {
+    # Cutoff blir i dag - 30 dager; filer fra 2020 er garantert eldre
+    export STUB_SSH_LS_OUTPUT="testprosjekt_20200101_030000.sql.gz.gpg
+testprosjekt_20200102_030000.sql.gz.gpg
+testprosjekt_20200103_030000.sql.gz.gpg"
+
+    load_backup_lib
+    run cleanup_hetzner
+
+    local call_count
+    call_count=$(wc -l < "$STUB_SSH_CALL_LOG")
+    [[ "$call_count" -le 2 ]]
+}
+
+@test "cleanup_hetzner gjør ingen rm-kall hvis ingen filer er eldre enn cutoff" {
+    # Filer fra fremtiden er garantert nyere enn cutoff
+    local future_date
+    future_date=$(date -d "+365 days" +%Y%m%d 2>/dev/null || date -v+365d +%Y%m%d 2>/dev/null || echo "20991231")
+    export STUB_SSH_LS_OUTPUT="testprosjekt_${future_date}_030000.sql.gz.gpg"
+
+    load_backup_lib
+    run cleanup_hetzner
+
+    # Kun ls-kallet forventes — ingen rm
+    ! grep -q ' rm ' "$STUB_SSH_CALL_LOG" 2>/dev/null
+}
+
+@test "cleanup_hetzner gjør ingen SSH-kall når Hetzner ikke er konfigurert" {
+    unset HETZNER_HOST
+
+    load_backup_lib
+    run cleanup_hetzner
+
+    local call_count
+    call_count=$(wc -l < "$STUB_SSH_CALL_LOG")
+    [[ "$call_count" -eq 0 ]]
+}

--- a/tests/stubs/ssh
+++ b/tests/stubs/ssh
@@ -4,5 +4,18 @@
 # samt sha256sum-verifiseringen (tom stdout -> remote_sha256 blir tom og
 # funksjonen logger advarsel, men returnerer 0).
 # Returnerer 1 hvis STUB_SSH_FAIL=1.
+#
+# Opt-in kallregistrering: sett STUB_SSH_CALL_LOG til en fil for å logge kall.
+# Opt-in ls-output: sett STUB_SSH_LS_OUTPUT for å returnere filnavn ved ls-kommandoer.
+
 [[ "${STUB_SSH_FAIL:-0}" == "1" ]] && exit 1
+
+if [[ -n "${STUB_SSH_CALL_LOG:-}" ]]; then
+    echo "$*" >> "$STUB_SSH_CALL_LOG"
+fi
+
+if [[ -n "${STUB_SSH_LS_OUTPUT:-}" ]] && [[ "$*" == *"ls "* ]]; then
+    echo "$STUB_SSH_LS_OUTPUT"
+fi
+
 exit 0


### PR DESCRIPTION
Fixes #30

Eliminerer N+1 SSH-tilkoblinger i `cleanup_hetzner()` ved å samle filer som skal slettes i en array og sende én `ssh rm` i stedet for ett kall per fil.