### PR TITLE
test: BATS-dekning for backup_files() retention (closes #31)

### DIFF
--- a/tests/retention.bats
+++ b/tests/retention.bats
@@ -72,3 +72,84 @@ teardown() {
 
     [ -f "$other_file" ]
 }
+
+# --- backup_files() retention ---
+
+setup_files_dir() {
+    local dir
+    dir="$(mktemp -d)"
+    echo "testinnhold" > "${dir}/fil.txt"
+    export FILES_DIR="$dir"
+}
+
+teardown_files_dir() {
+    rm -rf "$FILES_DIR"
+    unset FILES_DIR
+}
+
+@test "fil-backup retention sletter gamle .tar.gz.gpg-filer" {
+    setup_files_dir
+    local old_file="${BACKUP_DIR}/testprosjekt_files_20240101_030000.tar.gz.gpg"
+    touch -d "3 days ago" "$old_file"
+
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -eq 0 ]
+
+    [ ! -f "$old_file" ]
+
+    teardown_files_dir
+}
+
+@test "fil-backup retention sletter .sha256-fil tilhorende gammelt fil-backup" {
+    setup_files_dir
+    local old_file="${BACKUP_DIR}/testprosjekt_files_20240101_030000.tar.gz.gpg"
+    local old_sha="${old_file}.sha256"
+    touch -d "3 days ago" "$old_file" "$old_sha"
+
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -eq 0 ]
+
+    [ ! -f "$old_file" ]
+    [ ! -f "$old_sha" ]
+
+    teardown_files_dir
+}
+
+@test "fil-backup retention beholder nye fil-backups" {
+    setup_files_dir
+    local new_file="${BACKUP_DIR}/testprosjekt_files_$(date +%Y%m%d)_000000.tar.gz.gpg"
+    touch "$new_file"
+
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -eq 0 ]
+
+    [ -f "$new_file" ]
+
+    teardown_files_dir
+}
+
+@test "fil-backup retention roerer ikke fil-backups fra andre prosjekter" {
+    setup_files_dir
+    local other_file="${BACKUP_DIR}/annetprosjekt_files_20240101_030000.tar.gz.gpg"
+    touch -d "3 days ago" "$other_file"
+
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -eq 0 ]
+
+    [ -f "$other_file" ]
+
+    teardown_files_dir
+}
+
+@test "fil-backup retention sletter gamle ukrypterte .tar.gz-filer" {
+    setup_files_dir
+    local old_plain="${BACKUP_DIR}/testprosjekt_files_20240101_030000.tar.gz"
+    touch -d "3 days ago" "$old_plain"
+
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -eq 0 ]
+
+    [ ! -f "$old_plain" ]
+
+    teardown_files_dir
+}


### PR DESCRIPTION
Fixes #31

Legger til 5 tester i `tests/retention.bats` som dekker retention-logikken i `backup_files()`:

- Gamle `_files_*.tar.gz.gpg`-filer slettes etter retention-grense
- Tilhørende `.sha256`-filer slettes
- Nye fil-backups beholdes
- Filer fra andre prosjekter røres ikke
- Gamle ukrypterte `_files_*.tar.gz`-filer slettes via `-not -name "*.gpg"`-mønsteret