### PR TITLE
Fix #44: replace grep -oP with sed for BusyBox Alpine compatibility

### DIFF
--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -144,7 +144,7 @@ cleanup_hetzner() {
             continue
         fi
         local file_date
-        file_date=$(echo "$remote_file" | grep -oP "${PROJECT_NAME}_\K[0-9]{8}" || echo "")
+        file_date=$(echo "$remote_file" | sed -n "s/.*${PROJECT_NAME}_\([0-9]\{8\}\).*/\1/p" || echo "")
         if [[ -n "$file_date" ]] && [[ "$file_date" < "$cutoff_ts" ]]; then
             log "Markerer for sletting: $remote_file"
             files_to_delete+=("${HETZNER_BACKUP_PATH}/${remote_file}")

--- a/tests/hetzner_cleanup.bats
+++ b/tests/hetzner_cleanup.bats
@@ -101,3 +101,14 @@ testprosjekt_20200102_030000.sql.gz.gpg"
     # Begge filer skal markeres for sletting (rm-kall skal forekomme)
     grep -q ' rm ' "$STUB_SSH_CALL_LOG" 2>/dev/null
 }
+
+@test "cleanup_hetzner sletter gammel fil — dato-ekstraksjon med POSIX sed (BusyBox-kompatibel)" {
+    # grep -oP (Perl-regex) støttes ikke i BusyBox grep (postgres:16-alpine).
+    # Verifiserer at dato-ekstraksjon fungerer og at filen inkluderes i rm-kommandoen.
+    export STUB_SSH_LS_OUTPUT="testprosjekt_20200101_030000.sql.gz.gpg"
+
+    load_backup_lib
+    run cleanup_hetzner
+
+    grep -q 'testprosjekt_20200101_030000.sql.gz.gpg' "$STUB_SSH_CALL_LOG"
+}


### PR DESCRIPTION
Fixes #44

## Endring

Linje 147 i `backup-entrypoint.sh` brukte `grep -oP` (Perl-regex) for å ekstrahere dato fra filnavn. BusyBox `grep` i `postgres:16-alpine` støtter ikke `-P`-flagget — kommandoen feilet lydløst (exit 2), `file_date` ble alltid tom, og Hetzner-retention kjørte aldri.

**Fix**: Erstattet med `sed` (POSIX BRE) som fungerer på både BusyBox og GNU grep.

**Ny test**: Eksplisitt BATS-test som verifiserer at gammel fil inkluderes i rm-kommandoen — dokumenterer BusyBox-kompatibilitetskravet.