### PR TITLE
chore: bytt auto-merge.yml til grunnmur-access App-token

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -46,9 +46,16 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GRUNNMUR_APP_ID }}
+          private-key: ${{ secrets.GRUNNMUR_APP_KEY }}
+
       - name: Enable auto-merge
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUM: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |


### PR DESCRIPTION
## Sammendrag

Bytter `auto-merge.yml` fra `secrets.GITHUB_TOKEN` til `grunnmur-access` GitHub App-token.

## Hvorfor

GitHub fyrer ikke nye workflows fra pushes/PR-handlinger gjort av `GITHUB_TOKEN`. Dette har to symptomer:

1. **`Fixes #N` lukker ikke issues** — kun 4/19 i siste rolloutet
2. **`push:`-trigget workflows fyrer ikke** etter auto-merge (varde issue #119)

App-token løser begge fordi merge-aktøren blir App-installasjonen (TommySkogstad), som ikke er underlagt GITHUB_TOKEN-restriksjonen.

## Endringer

- Legg til `actions/create-github-app-token@v2` step
- Bytt `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` → `GH_TOKEN: ${{ steps.app-token.outputs.token }}`

## Test plan

- [ ] CI grønn
- [ ] Etter merge: neste auto/* eller fix/* PR med `Fixes #N` skal lukke issuen automatisk
- [ ] Push-trigger-workflows skal fyre etter auto-merge

Ref: misc-scripts#404 (sub-issue av #403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)