### PR TITLE
security: pin postgres base image to 16.13-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:16-alpine
+FROM postgres:16.13-alpine
 
 RUN apk add --no-cache \
     bash \


### PR DESCRIPTION
## Sammendrag

- Bytter `FROM postgres:16-alpine` til `FROM postgres:16.13-alpine` i `Dockerfile`
- Matcher pinningen alle 4 Kotlin-appene (lo-finans, biologportal, 6810, styreportal) allerede bruker i docker-compose
- Gjør bygget reproduserbart og hindrer at `docker pull` stille henter nye patch-versjoner

## Test plan

- [x] CI: hadolint + shellcheck + BATS + docker build
- [ ] Smoke etter merge: `docker compose -f docker-compose.tunnel.yml exec backup pg_dump --version` (verifiserer at `pg_dump` fortsatt fungerer i container)

Fixes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)