### PR TITLE
Fix #60: skriv BACKUP_SUCCESS_FILE i main() etter begge backup-kall

### DIFF
--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -218,7 +218,6 @@ run_backup() {
     cleanup_hetzner
 
     log "Backup fullfort OK"
-    date +%s > "$BACKUP_SUCCESS_FILE"
 }
 
 upload_with_retry() {
@@ -282,7 +281,6 @@ backup_files() {
     find "$BACKUP_DIR" -name "${PROJECT_NAME}_files_*.tar.gz" -not -name "*.gpg" -mtime "+${BACKUP_RETENTION_DAYS}" -delete 2>/dev/null || true
 
     log "Fil-backup fullfort OK"
-    date +%s > "$BACKUP_SUCCESS_FILE"
 }
 
 main() {
@@ -294,12 +292,14 @@ main() {
     if [[ "${1:-}" == "backup" ]]; then
         run_backup
         backup_files
+        date +%s > "$BACKUP_SUCCESS_FILE"
         exit 0
     fi
 
     log "Kjorer initial backup..."
     run_backup
     backup_files
+    date +%s > "$BACKUP_SUCCESS_FILE"
 
     log "Setter opp daglig backup: $BACKUP_SCHEDULE"
     # Eksporter miljovariabler til fil for cron (BusyBox crond arver ikke Docker env)

--- a/tests/run_backup.bats
+++ b/tests/run_backup.bats
@@ -78,6 +78,21 @@ teardown() {
     [ "$files" -eq 0 ]
 }
 
+@test "BACKUP_SUCCESS_FILE skrives ikke naar backup_files feiler (GPG-feil under fil-backup)" {
+    local files_dir
+    files_dir="$(mktemp -d)"
+    touch "$files_dir/testfil.txt"
+    export FILES_DIR="$files_dir"
+    export STUB_GPG_FAIL_FILES=1
+
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -ne 0 ]
+
+    [ ! -f "$BACKUP_SUCCESS_FILE" ]
+
+    rm -rf "$files_dir"
+}
+
 @test "run_backup feiler med feilmelding og forsoksteller naar database aldri starter (DB_WAIT_TIMEOUT)" {
     export STUB_PGISREADY_FAIL=always
     export DB_WAIT_TIMEOUT=4

--- a/tests/stubs/gpg
+++ b/tests/stubs/gpg
@@ -2,6 +2,8 @@
 # Stub for gpg. Pipe stdin direkte til stdout — fungerer for baade
 # --symmetric (krypter) og --decrypt siden ekte gzip ligger i pipelinen.
 # Returnerer 1 hvis STUB_GPG_FAIL=1.
+# Returnerer 1 paa andre krypteringskall hvis STUB_GPG_FAIL_FILES=1
+# (simulerer GPG-feil under fil-backup men ikke DB-backup).
 #
 # Lukker fd 3 eksplisitt for aa unngaa at process substitution
 # (--passphrase-fd 3 3< <(printf ...)) henger paa blokkert pipe.
@@ -10,6 +12,26 @@
 exec 3<&- 2>/dev/null || true
 
 [[ "${STUB_GPG_FAIL:-0}" == "1" ]] && exit 1
+
+# STUB_GPG_FAIL_FILES=1: feil paa andre krypteringskall (backup_files sin kryptering)
+# Bruk kalltellerfilm i tmpdir for aa telle krypteringskall (kun --symmetric)
+if [[ "${STUB_GPG_FAIL_FILES:-0}" == "1" ]]; then
+    for arg in "$@"; do
+        if [[ "$arg" == "--symmetric" ]]; then
+            COUNTER_FILE="${TMPDIR:-/tmp}/stub_gpg_encrypt_count_$$"
+            # Finn teller-filen basert paa BACKUP_DIR for aa vaere prosess-uavhengig
+            COUNTER_FILE="${TMPDIR:-/tmp}/stub_gpg_encrypt_count_${BACKUP_DIR//\//_}"
+            count=0
+            [[ -f "$COUNTER_FILE" ]] && count=$(cat "$COUNTER_FILE")
+            count=$(( count + 1 ))
+            echo "$count" > "$COUNTER_FILE"
+            if [[ "$count" -ge 2 ]]; then
+                exit 1
+            fi
+            break
+        fi
+    done
+fi
 
 # Passthrough: stdin -> stdout
 cat


### PR DESCRIPTION
Fixes #60

## Hva ble gjort

Flyttet `date +%s > "$BACKUP_SUCCESS_FILE"` ut av `run_backup()` og `backup_files()` og inn i `main()` etter at begge kall har fullført. Feiler nå ett av dem, skrives ikke suksess-filen og healthcheck-sier korrekt `unhealthy`.

## Endrede filer
- `backup-entrypoint.sh`: Fjernet suksess-fil-skriving fra individuelle funksjoner, lagt til én gang i `main()`
- `tests/run_backup.bats`: Ny regresjonstest som verifiserer at `BACKUP_SUCCESS_FILE` ikke skrives når fil-backup feiler
- `tests/stubs/gpg`: Støtte for `STUB_GPG_FAIL_FILES=1` — feiler kun på andre krypteringskall (simulerer GPG-feil under `backup_files()`)