### PR TITLE
Fix #61: pin postgres:16.13-alpine til digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:16.13-alpine
+FROM postgres:16.13-alpine@sha256:4e6e670bb069649261c9c18031f0aded7bb249a5b6664ddec29c013a89310d50
 
 RUN apk add --no-cache \
     bash \


### PR DESCRIPTION
Fixes #61

Pinner `FROM postgres:16.13-alpine` til digest `sha256:4e6e670bb069649261c9c18031f0aded7bb249a5b6664ddec29c013a89310d50` for reproduserbare og sporbare builds uten risiko for stille lag-endringer.

Dependabot Docker-cron er allerede aktiv og vil håndtere fremtidige digest-bump automatisk.