### PR TITLE
fix: quote env values in cron env file to handle spaces

### DIFF
--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -303,7 +303,7 @@ main() {
 
     log "Setter opp daglig backup: $BACKUP_SCHEDULE"
     # Eksporter miljovariabler til fil for cron (BusyBox crond arver ikke Docker env)
-    env | grep -E '^(PROJECT_NAME|DB_|BACKUP_|FILES_DIR|HETZNER_|TZ)[^=]*=' | sed 's/^\(.*\)$/export \1/' > "$SAFEKEEPER_ENV_FILE"
+    env | grep -E '^(PROJECT_NAME|DB_|BACKUP_|FILES_DIR|HETZNER_|TZ)[^=]*=' | sed "s/^\\([^=]*\\)=\\(.*\\)\$/export \\1='\\2'/" > "$SAFEKEEPER_ENV_FILE"
     chmod 600 "$SAFEKEEPER_ENV_FILE"
     echo "$BACKUP_SCHEDULE . $SAFEKEEPER_ENV_FILE; /usr/local/bin/backup-entrypoint.sh backup >> /var/log/backup.log 2>&1" > "$CRONTAB_FILE"
 


### PR DESCRIPTION
## Problem

`umami-prod-backup-1` har vært unhealthy siden 2026-05-15 fordi cron-daemon aldri startet.

**Rotårsak:** Linje 306 i `backup-entrypoint.sh` genererte ugyldige `export`-linjer:

```
export BACKUP_SCHEDULE=0 3 * * *
```

Når BusyBox crond sourcerer denne filen via `/bin/sh`, tolker den `3` som et eget argument til `export` → `bad variable name` → cron krasjer → ingen planlagte backups → healthcheck feiler etter 26 timer.

## Fix

Values wrapper nå i enkeltanførselstegn:

```
export BACKUP_SCHEDULE='0 3 * * *'
```

## Test plan

- [ ] CI (ShellCheck + BATS) grønn
- [ ] Restart `umami-prod-backup-1` etter merge og verifiser at container blir healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)