### PR TITLE
Fix #74: Silent failure på kritiske backup-operasjoner (mkdir, rm, find)

### DIFF
--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -116,7 +116,9 @@ upload_to_hetzner() {
         [[ -z "$part" ]] && continue
         current_path="${current_path:+${current_path}/}${part}"
         # shellcheck disable=SC2029 # lokal ekspansjon tilsiktet — verdier validert i check_requirements()
-        ssh "${SSH_OPTS[@]}" "${HETZNER_USER}@${HETZNER_HOST}" mkdir "${current_path}" 2>/dev/null || true
+        ssh "${SSH_OPTS[@]}" "${HETZNER_USER}@${HETZNER_HOST}" mkdir "${current_path}" 2>/dev/null \
+            || ssh "${SSH_OPTS[@]}" "${HETZNER_USER}@${HETZNER_HOST}" test -d "${current_path}" \
+            || { log "ADVARSEL: Kan ikke opprette eller bekrefte katalog '${current_path}' på Hetzner"; return 1; }
     done
 
     # Generer checksum for verifisering etter opplasting
@@ -140,7 +142,8 @@ upload_to_hetzner() {
     if [[ "$local_sha256" == "$remote_sha256" ]]; then
         log "Offsite backup lastet opp og verifisert: ${HETZNER_BACKUP_PATH}/${filename}"
     elif [[ -z "$remote_sha256" ]]; then
-        log "ADVARSEL: Kunne ikke verifisere checksum pa Hetzner (sha256sum utilgjengelig)"
+        log "ADVARSEL: Kunne ikke verifisere checksum på Hetzner (sha256sum utilgjengelig) — regnes som opplastingsfeil"
+        return 1
     else
         log "ADVARSEL: Checksum-mismatch etter opplasting! Lokal=$local_sha256 Remote=$remote_sha256"
         return 1
@@ -176,7 +179,8 @@ cleanup_hetzner() {
         log "Sletter ${#files_to_delete[@]} gammel(e) offsite backup(s)..."
         # shellcheck disable=SC2029 # lokal ekspansjon tilsiktet — verdier validert i check_requirements()
         ssh "${SSH_OPTS[@]}" "${HETZNER_USER}@${HETZNER_HOST}" \
-            rm "${files_to_delete[@]}" 2>/dev/null || true
+            rm "${files_to_delete[@]}" \
+            || log "ADVARSEL: Sletting av gamle Hetzner-backups feilet — filer kan akkumulere"
     fi
 }
 
@@ -230,10 +234,13 @@ run_backup() {
     upload_with_retry "${backup_file}.sha256"
 
     # Slett lokale backups eldre enn BACKUP_RETENTION_DAYS
-    find "$BACKUP_DIR" -name "${PROJECT_NAME}_*.sql.gz.gpg" -mtime "+${BACKUP_RETENTION_DAYS}" -delete 2>/dev/null || true
-    find "$BACKUP_DIR" -name "${PROJECT_NAME}_*.sql.gz.gpg.sha256" -mtime "+${BACKUP_RETENTION_DAYS}" -delete 2>/dev/null || true
+    find "$BACKUP_DIR" -name "${PROJECT_NAME}_*.sql.gz.gpg" -mtime "+${BACKUP_RETENTION_DAYS}" -delete \
+        || log "ADVARSEL: Fjerning av gamle lokale DB-backups feilet — sjekk rettigheter på $BACKUP_DIR"
+    find "$BACKUP_DIR" -name "${PROJECT_NAME}_*.sql.gz.gpg.sha256" -mtime "+${BACKUP_RETENTION_DAYS}" -delete \
+        || log "ADVARSEL: Fjerning av gamle lokale checksum-filer feilet — sjekk rettigheter på $BACKUP_DIR"
     # Rydd opp eventuelle gamle ukrypterte backups
-    find "$BACKUP_DIR" -name "${PROJECT_NAME}_*.sql.gz" -not -name "*.gpg" -mtime "+${BACKUP_RETENTION_DAYS}" -delete 2>/dev/null || true
+    find "$BACKUP_DIR" -name "${PROJECT_NAME}_*.sql.gz" -not -name "*.gpg" -mtime "+${BACKUP_RETENTION_DAYS}" -delete \
+        || log "ADVARSEL: Fjerning av gamle ukrypterte lokale backups feilet — sjekk rettigheter på $BACKUP_DIR"
 
     # Slett gamle backups pa Hetzner
     cleanup_hetzner
@@ -296,10 +303,13 @@ backup_files() {
     upload_with_retry "${backup_file}.sha256"
 
     # Rydd opp gamle fil-backups
-    find "$BACKUP_DIR" -name "${PROJECT_NAME}_files_*.tar.gz.gpg" -mtime "+${BACKUP_RETENTION_DAYS}" -delete 2>/dev/null || true
-    find "$BACKUP_DIR" -name "${PROJECT_NAME}_files_*.tar.gz.gpg.sha256" -mtime "+${BACKUP_RETENTION_DAYS}" -delete 2>/dev/null || true
+    find "$BACKUP_DIR" -name "${PROJECT_NAME}_files_*.tar.gz.gpg" -mtime "+${BACKUP_RETENTION_DAYS}" -delete \
+        || log "ADVARSEL: Fjerning av gamle lokale fil-backups feilet — sjekk rettigheter på $BACKUP_DIR"
+    find "$BACKUP_DIR" -name "${PROJECT_NAME}_files_*.tar.gz.gpg.sha256" -mtime "+${BACKUP_RETENTION_DAYS}" -delete \
+        || log "ADVARSEL: Fjerning av gamle lokale fil-backup checksum-filer feilet — sjekk rettigheter på $BACKUP_DIR"
     # Rydd opp eventuelle gamle ukrypterte fil-backups
-    find "$BACKUP_DIR" -name "${PROJECT_NAME}_files_*.tar.gz" -not -name "*.gpg" -mtime "+${BACKUP_RETENTION_DAYS}" -delete 2>/dev/null || true
+    find "$BACKUP_DIR" -name "${PROJECT_NAME}_files_*.tar.gz" -not -name "*.gpg" -mtime "+${BACKUP_RETENTION_DAYS}" -delete \
+        || log "ADVARSEL: Fjerning av gamle ukrypterte lokale fil-backups feilet — sjekk rettigheter på $BACKUP_DIR"
 
     log "Fil-backup fullfort OK"
 }

--- a/tests/hetzner_cleanup.bats
+++ b/tests/hetzner_cleanup.bats
@@ -91,6 +91,16 @@ testprosjekt_20200103_030000.sql.gz.gpg"
     echo "$output" | grep -q "ADVARSEL"
 }
 
+@test "cleanup_hetzner logger advarsel naar SSH rm-kommando feiler" {
+    export STUB_SSH_LS_OUTPUT="testprosjekt_20200101_030000.sql.gz.gpg"
+    export STUB_SSH_RM_FAIL=1
+
+    load_backup_lib
+    run cleanup_hetzner
+
+    [[ "$output" == *"ADVARSEL"* ]]
+}
+
 @test "cleanup_hetzner behandler gyldige filnavn normalt" {
     export STUB_SSH_LS_OUTPUT="testprosjekt_20200101_030000.sql.gz.gpg
 testprosjekt_20200102_030000.sql.gz.gpg"

--- a/tests/hetzner_retry.bats
+++ b/tests/hetzner_retry.bats
@@ -28,11 +28,11 @@ teardown() {
     rm -rf "$BACKUP_DIR"
 }
 
-# Laster backup-entrypoint.sh som bibliotek uten aa kjore main.
-# Populerer deretter SSH_KEY saa hetzner_configured returnerer sant.
+# Laster backup-entrypoint.sh som bibliotek uten main og uten set -euo pipefail
+# (set -euo pipefail forstyrrer BATS sin feilhåndtering i testsuiten).
 load_backup_lib() {
     local stripped
-    stripped=$(sed 's|^main "\$@".*$|:|' "$SAFEKEEPER_ROOT/backup-entrypoint.sh")
+    stripped=$(sed 's|^main "\$@".*$|:|; s|^set -euo pipefail.*$|:|; s|^trap cleanup EXIT.*$|:|' "$SAFEKEEPER_ROOT/backup-entrypoint.sh")
     eval "$stripped"
     echo "dummy-ssh-key" > "$SSH_KEY"
 }
@@ -73,13 +73,25 @@ load_backup_lib() {
     [[ "$output" == *"forsok 2/3"* ]]
 }
 
-@test "upload_to_hetzner logger advarsel og returnerer 0 ved tom sha256sum-respons" {
+@test "upload_to_hetzner logger advarsel og returnerer 1 ved tom sha256sum-respons" {
     load_backup_lib
 
     local dummy="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
     echo "content" > "$dummy"
 
     run upload_to_hetzner "$dummy"
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 1 ]
     [[ "$output" == *"Kunne ikke verifisere checksum"* ]]
+}
+
+@test "upload_to_hetzner returnerer 1 og logger katalog-feil naar mkdir og test-d begge feiler paa Hetzner" {
+    export STUB_SSH_FAIL=1
+    load_backup_lib
+
+    local dummy="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
+    echo "content" > "$dummy"
+
+    run upload_to_hetzner "$dummy"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"katalog"* ]]
 }

--- a/tests/stubs/ssh
+++ b/tests/stubs/ssh
@@ -7,6 +7,7 @@
 #
 # Opt-in kallregistrering: sett STUB_SSH_CALL_LOG til en fil for å logge kall.
 # Opt-in ls-output: sett STUB_SSH_LS_OUTPUT for å returnere filnavn ved ls-kommandoer.
+# Opt-in rm-feil: sett STUB_SSH_RM_FAIL=1 for å simulere at rm-kommandoer feiler.
 
 [[ "${STUB_SSH_FAIL:-0}" == "1" ]] && exit 1
 
@@ -20,6 +21,10 @@ fi
 
 if [[ "${STUB_SSH_WRONG_CHECKSUM:-0}" == "1" ]] && [[ "$*" == *"sha256sum"* ]]; then
     echo "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  /stub/file"
+fi
+
+if [[ "${STUB_SSH_RM_FAIL:-0}" == "1" ]] && [[ "$*" == *" rm "* ]]; then
+    exit 1
 fi
 
 exit 0


### PR DESCRIPTION
Fixes #74

## Endringer

**`backup-entrypoint.sh`:**
- SSH `mkdir`: legger til `test -d`-fallback — skiller «katalog finnes» (OK) fra ekte feil (permission denied, SSH nede). Returnerer 1 og logger ADVARSEL hvis begge feiler.
- SSH `rm` på Hetzner: fjerner `2>/dev/null || true`, logger ADVARSEL ved feil slik at filakkumulering er synlig.
- `find -delete` (×6): fjerner `2>/dev/null || true`, logger ADVARSEL med hint om rettighetsproblem.
- Tom `remote_sha256`: returnerer nå 1 (trigger retry i `upload_with_retry`) i stedet for 0.

**Tester:**
- Oppdatert checksum-test til å forvente `status -eq 1`
- Ny test: `upload_to_hetzner returnerer 1 og logger katalog-feil naar mkdir og test-d feiler`
- Ny test: `cleanup_hetzner logger advarsel naar SSH rm feilet`
- `load_backup_lib` i `hetzner_retry.bats` stripper nå `set -euo pipefail` (slik som `hetzner_cleanup.bats`) for å unngå BATS-interferens
- SSH-stub: ny `STUB_SSH_RM_FAIL`-variabel