### PR TITLE
fix: input-validering og testforbedringer etter QA-review av #78

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,7 @@ gh run list --repo TommySkogstad/safekeeper --limit 5
 - **set -euo pipefail**: Alle skript bruker streng feilhandtering.
 - **Eksplisitte advarsler ved kritiske operasjoner**: Operasjoner som `mkdir`, `rm`, `find -delete` og checksum-verifikasjoner må aldri silently feile med `|| true`. I stedet: logg `ADVARSEL` med kontekst og returner feilkode. Eksempler: mkdir som mislykkes skal sjekke `test -d` og advare hvis både create og verify feiler; rm som mislykkes skal advare om rettigheter; find som mislykkes skal advare om disk-problemer.
 - **Healthcheck**: Containeren skriver `/tmp/last-backup-success` med timestamp når BÅDE database-backup og fil-backup (hvis konfigurert) er vellykkede. Healthcheck sjekker at siste backup var innen `BACKUP_HEALTHCHECK_WINDOW` sekunder (default 93600 = 26 timer).
-- **Retry-logikk**: Hetzner-opplasting prover 3 ganger med eksponentiell backoff (5s, 10s, 20s).
+- **Retry-logikk**: Hetzner-opplasting prover `BACKUP_RETRY_MAX` ganger (default 3) med eksponentiell backoff (startverdi `BACKUP_RETRY_DELAY` sekunder, default 5s).
 - **Retention**: Gamle backups slettes automatisk bade lokalt og pa Hetzner etter `BACKUP_RETENTION_DAYS`.
 - **Initial backup**: Ved oppstart kjores en backup umiddelbart for cron settes opp.
 - **Linting**: ShellCheck for bash, Hadolint for Dockerfile. Begge ma passere i CI.

--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -77,6 +77,13 @@ check_requirements() {
 
     [[ "$PROJECT_NAME" =~ ^[a-zA-Z0-9._-]{1,64}$ ]] || error "PROJECT_NAME inneholder ugyldige tegn: '$PROJECT_NAME'"
 
+    [[ "$BACKUP_RETRY_MAX" =~ ^[0-9]+$ ]] && [[ "$BACKUP_RETRY_MAX" -ge 1 ]] \
+        || error "BACKUP_RETRY_MAX må være et positivt heltall >= 1, fikk: '$BACKUP_RETRY_MAX'"
+    [[ "$BACKUP_RETRY_DELAY" =~ ^[0-9]+$ ]] && [[ "$BACKUP_RETRY_DELAY" -ge 1 ]] \
+        || error "BACKUP_RETRY_DELAY må være et positivt heltall >= 1, fikk: '$BACKUP_RETRY_DELAY'"
+    [[ "$BACKUP_HEALTHCHECK_WINDOW" =~ ^[0-9]+$ ]] && [[ "$BACKUP_HEALTHCHECK_WINDOW" -ge 1 ]] \
+        || error "BACKUP_HEALTHCHECK_WINDOW må være et positivt heltall >= 1, fikk: '$BACKUP_HEALTHCHECK_WINDOW'"
+
     if [[ -n "$HETZNER_HOST" ]]; then
         [[ "$HETZNER_HOST" =~ ^[a-zA-Z0-9.-]+$ ]] || error "HETZNER_HOST inneholder ugyldige tegn: '$HETZNER_HOST'"
         if [[ -n "$HETZNER_USER" ]]; then

--- a/tests/hetzner_retry.bats
+++ b/tests/hetzner_retry.bats
@@ -39,6 +39,7 @@ load_backup_lib() {
 
 @test "upload_with_retry prover 3 ganger ved vedvarende scp-feil" {
     export STUB_SCP_FAIL=1
+    export BACKUP_RETRY_MAX=3
     load_backup_lib
 
     local dummy="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
@@ -51,6 +52,7 @@ load_backup_lib() {
 
 @test "upload_with_retry logger 'etter 3 forsok' ved total feil" {
     export STUB_SCP_FAIL=1
+    export BACKUP_RETRY_MAX=3
     load_backup_lib
 
     local dummy="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
@@ -62,6 +64,7 @@ load_backup_lib() {
 
 @test "upload_with_retry prover pa nytt ved checksum-mismatch etter opplasting" {
     export STUB_SSH_WRONG_CHECKSUM=1
+    export BACKUP_RETRY_MAX=3
     load_backup_lib
 
     local dummy="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"


### PR DESCRIPTION
Oppfølging etter QA-review av PR #83.

- Legger til -validering for ,  og  (ugyldig input gir tydelig feilmelding istedenfor bash arithmetic error)
- Gjør eksisterende tester eksplisitte ved å sette  (ikke avhengig av default)
- Oppdaterer CLAUDE.md retry-logikk-beskrivelse til å referere konfigurerbare env-variabler