### PR TITLE
Fix #85: SSH-stub med STUB_SSH_EXIT + permission_denied og timeout-tester

### DIFF
--- a/tests/hetzner_retry.bats
+++ b/tests/hetzner_retry.bats
@@ -125,3 +125,27 @@ load_backup_lib() {
     [[ "$output" == *"feilet etter 2 forsok"* ]]
     [[ "$output" != *"forsok 2/2"* ]]
 }
+
+@test "upload_to_hetzner returnerer 1 og logger katalog-feil ved SSH permission denied (STUB_SSH_EXIT=permission_denied)" {
+    export STUB_SSH_EXIT=permission_denied
+    load_backup_lib
+
+    local dummy="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
+    echo "content" > "$dummy"
+
+    run upload_to_hetzner "$dummy"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"katalog"* ]]
+}
+
+@test "upload_to_hetzner returnerer 1 og logger katalog-feil ved SSH timeout (STUB_SSH_EXIT=timeout, exit 255)" {
+    export STUB_SSH_EXIT=timeout
+    load_backup_lib
+
+    local dummy="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
+    echo "content" > "$dummy"
+
+    run upload_to_hetzner "$dummy"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"katalog"* ]]
+}

--- a/tests/run_backup.bats
+++ b/tests/run_backup.bats
@@ -25,6 +25,15 @@ teardown() {
     rm -f "${TMPDIR:-/tmp}/stub_gpg_encrypt_count_${BACKUP_DIR//\//_}"
 }
 
+# Laster backup-entrypoint.sh som bibliotek uten main og uten set -euo pipefail
+# slik at enkeltfunksjoner kan kalles direkte. Brukes av Hetzner-relaterte tester.
+load_backup_lib() {
+    local stripped
+    stripped=$(sed 's|^main "\$@".*$|:|; s|^set -euo pipefail.*$|:|; s|^trap cleanup EXIT.*$|:|' "$SAFEKEEPER_ROOT/backup-entrypoint.sh")
+    eval "$stripped"
+    echo "dummy-ssh-key" > "$SSH_KEY"
+}
+
 @test "run_backup oppretter kryptert backup-fil i BACKUP_DIR" {
     run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
     [ "$status" -eq 0 ]
@@ -102,4 +111,21 @@ teardown() {
     [ "$status" -ne 0 ]
     [[ "$output" == *"ikke tilgjengelig"* ]]
     [[ "$output" == *"forsok"* ]]
+}
+
+@test "run_backup logger ADVARSEL og katalog-feil ved SSH permission denied paa Hetzner mkdir (lokal backup ok)" {
+    export HETZNER_HOST=hetzner.example
+    export HETZNER_USER=u12345
+    export STUB_SSH_EXIT=permission_denied
+    export BACKUP_RETRY_MAX=1
+    load_backup_lib
+
+    run run_backup
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ADVARSEL"* ]]
+    [[ "$output" == *"katalog"* ]]
+
+    local files
+    files=$(find "$BACKUP_DIR" -maxdepth 1 -name "testprosjekt_*.sql.gz.gpg" | wc -l)
+    [ "$files" -eq 1 ]
 }

--- a/tests/stubs/ssh
+++ b/tests/stubs/ssh
@@ -5,9 +5,18 @@
 # funksjonen logger advarsel, men returnerer 0).
 # Returnerer 1 hvis STUB_SSH_FAIL=1.
 #
+# Opt-in exit-mode: sett STUB_SSH_EXIT for å simulere spesifikke SSH-feil.
+# Støttede verdier: permission_denied (exit 1), timeout (exit 255), eller numerisk exit-kode.
 # Opt-in kallregistrering: sett STUB_SSH_CALL_LOG til en fil for å logge kall.
 # Opt-in ls-output: sett STUB_SSH_LS_OUTPUT for å returnere filnavn ved ls-kommandoer.
 # Opt-in rm-feil: sett STUB_SSH_RM_FAIL=1 for å simulere at rm-kommandoer feiler.
+
+case "${STUB_SSH_EXIT:-}" in
+    permission_denied) echo "Permission denied (publickey)." >&2; exit 1 ;;
+    timeout)           exit 255 ;;
+    "")                ;;
+    *)                 exit "${STUB_SSH_EXIT}" ;;
+esac
 
 [[ "${STUB_SSH_FAIL:-0}" == "1" ]] && exit 1
 


### PR DESCRIPTION
Fixes #85. Del av #79.

## Endringer
- `tests/stubs/ssh`: Ny `STUB_SSH_EXIT`-case-statement med støtte for `permission_denied` (exit 1 + stderr-melding), `timeout` (exit 255), og numerisk fallback. Bakoverkompatibel med eksisterende `STUB_SSH_FAIL=1`-bruk.
- `tests/hetzner_retry.bats`: To nye tester for `upload_to_hetzner` med `STUB_SSH_EXIT=permission_denied` og `STUB_SSH_EXIT=timeout`
- `tests/run_backup.bats`: Ny `hetzner_mkdir_permission_denied_test` (bruker `load_backup_lib`-mønster) som verifiserer at full `run_backup`-flyt logger ADVARSEL og katalog-feil men lykkes lokalt når SSH permission denied