### PR TITLE
refactor: remove BACKUP_HEALTHCHECK_WINDOW from entrypoint (closes #94)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,6 @@ openssl rand -base64 32
 | `BACKUP_ENCRYPTION_KEY` | GPG-krypteringsnokkel (AES256) | - | Ja |
 | `BACKUP_RETRY_MAX` | Maks antall Hetzner-opplastingsforsøk | `3` | Nei |
 | `BACKUP_RETRY_DELAY` | Startverdien (sekunder) for eksponentiell backoff ved retry | `5` | Nei |
-| `BACKUP_HEALTHCHECK_WINDOW` | Maks alder (sekunder) på siste vellykkede backup for healthcheck | `93600` | Nei |
 | `FILES_DIR` | Katalog for fil-backup (tom = deaktivert) | (tom) | Nei |
 | `HETZNER_HOST` | Hetzner StorageBox hostname (tom = deaktivert) | (tom) | Nei |
 | `HETZNER_USER` | Hetzner StorageBox brukernavn | (tom) | Nei |
@@ -190,7 +189,7 @@ gh run list --repo TommySkogstad/safekeeper --limit 5
 - **Norsk logging**: Alle loggmeldinger er pa norsk.
 - **set -euo pipefail**: Alle skript bruker streng feilhandtering.
 - **Eksplisitte advarsler ved kritiske operasjoner**: Operasjoner som `mkdir`, `rm`, `find -delete` og checksum-verifikasjoner må aldri silently feile med `|| true`. I stedet: logg `ADVARSEL` med kontekst og returner feilkode. Eksempler: mkdir som mislykkes skal sjekke `test -d` og advare hvis både create og verify feiler; rm som mislykkes skal advare om rettigheter; find som mislykkes skal advare om disk-problemer.
-- **Healthcheck**: Containeren skriver `/tmp/last-backup-success` med timestamp når BÅDE database-backup og fil-backup (hvis konfigurert) er vellykkede. Healthcheck sjekker at siste backup var innen `BACKUP_HEALTHCHECK_WINDOW` sekunder (default 93600 = 26 timer).
+- **Healthcheck**: Containeren skriver `/tmp/last-backup-success` med timestamp når BÅDE database-backup og fil-backup (hvis konfigurert) er vellykkede. Healthcheck-vinduet (antall sekunder siden siste vellykkede backup) styres av consumer-appens docker-compose og er ikke en safekeeper-variabel — typisk 93600 (26 timer).
 - **Retry-logikk**: Hetzner-opplasting prover `BACKUP_RETRY_MAX` ganger (default 3) med eksponentiell backoff (startverdi `BACKUP_RETRY_DELAY` sekunder, default 5s).
 - **Retention**: Gamle backups slettes automatisk bade lokalt og pa Hetzner etter `BACKUP_RETENTION_DAYS`.
 - **Initial backup**: Ved oppstart kjores en backup umiddelbart for cron settes opp.
@@ -208,7 +207,7 @@ backup:
     dockerfile: Dockerfile
   restart: unless-stopped
   healthcheck:
-    test: ["CMD-SHELL", "test -f /tmp/last-backup-success && [ $(($(date +%s) - $(cat /tmp/last-backup-success))) -lt ${BACKUP_HEALTHCHECK_WINDOW:-93600} ]"]
+    test: ["CMD-SHELL", "test -f /tmp/last-backup-success && [ $(($(date +%s) - $(cat /tmp/last-backup-success))) -lt 93600 ]"]
     interval: 60s
     timeout: 10s
     retries: 3

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Alt styres via miljovariabler - ingen prosjektspesifikk kode.
 | `BACKUP_ENCRYPTION_KEY` | GPG-krypteringsnokkel (AES256) | - | Ja |
 | `BACKUP_RETRY_MAX` | Maks antall Hetzner-opplastingsforsøk | `3` | Nei |
 | `BACKUP_RETRY_DELAY` | Startverdien (sekunder) for eksponentiell backoff ved retry | `5` | Nei |
-| `BACKUP_HEALTHCHECK_WINDOW` | Maks alder (sekunder) på siste vellykkede backup for healthcheck | `93600` | Nei |
 | `FILES_DIR` | Katalog for fil-backup | (tom = deaktivert) | Nei |
 | `HETZNER_HOST` | Hetzner StorageBox hostname | (tom = deaktivert) | Nei |
 | `HETZNER_USER` | Hetzner StorageBox brukernavn | (tom) | Nei |
@@ -56,7 +55,7 @@ backup:
     dockerfile: Dockerfile
   restart: unless-stopped
   healthcheck:
-    test: ["CMD-SHELL", "test -f /tmp/last-backup-success && [ $(($(date +%s) - $(cat /tmp/last-backup-success))) -lt ${BACKUP_HEALTHCHECK_WINDOW:-93600} ]"]
+    test: ["CMD-SHELL", "test -f /tmp/last-backup-success && [ $(($(date +%s) - $(cat /tmp/last-backup-success))) -lt 93600 ]"]
     interval: 60s
     timeout: 10s
     retries: 3
@@ -72,7 +71,6 @@ backup:
     BACKUP_SCHEDULE: ${BACKUP_SCHEDULE:-0 3 * * *}
     BACKUP_RETRY_MAX: ${BACKUP_RETRY_MAX:-3}
     BACKUP_RETRY_DELAY: ${BACKUP_RETRY_DELAY:-5}
-    BACKUP_HEALTHCHECK_WINDOW: ${BACKUP_HEALTHCHECK_WINDOW:-93600}
     BACKUP_DIR: /backups
     BACKUP_ENCRYPTION_KEY: ${BACKUP_ENCRYPTION_KEY:?Sett BACKUP_ENCRYPTION_KEY i .env}
     HETZNER_HOST: ${HETZNER_HOST:-}
@@ -89,7 +87,7 @@ backup:
     - internal
 ```
 
-**Healthcheck**: Sjekker at siste backup var vellykket innen 26 timer (93600 sekunder). Containeren rapporterer `unhealthy` hvis backup ikke har kjort.
+**Healthcheck**: Sjekker at siste backup var vellykket innen 26 timer (93600 sekunder). Vinduet styres av consumer-appens docker-compose og kan tilpasses direkte i `test`-linjen. Containeren rapporterer `unhealthy` hvis backup ikke har kjort.
 
 ## Hetzner StorageBox oppsett
 

--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -26,7 +26,6 @@ BACKUP_ENCRYPTION_KEY="${BACKUP_ENCRYPTION_KEY:-}"
 DB_WAIT_TIMEOUT="${DB_WAIT_TIMEOUT:-60}"
 BACKUP_RETRY_MAX="${BACKUP_RETRY_MAX:-3}"
 BACKUP_RETRY_DELAY="${BACKUP_RETRY_DELAY:-5}"
-BACKUP_HEALTHCHECK_WINDOW="${BACKUP_HEALTHCHECK_WINDOW:-93600}"
 
 # Interne fil-stier (kan overstyres i tester via env-variabler)
 SAFEKEEPER_ENV_FILE="${SAFEKEEPER_ENV_FILE:-/etc/safekeeper.env}"
@@ -81,8 +80,6 @@ check_requirements() {
         || error "BACKUP_RETRY_MAX må være et positivt heltall >= 1, fikk: '$BACKUP_RETRY_MAX'"
     [[ "$BACKUP_RETRY_DELAY" =~ ^[0-9]+$ ]] && [[ "$BACKUP_RETRY_DELAY" -ge 1 ]] \
         || error "BACKUP_RETRY_DELAY må være et positivt heltall >= 1, fikk: '$BACKUP_RETRY_DELAY'"
-    [[ "$BACKUP_HEALTHCHECK_WINDOW" =~ ^[0-9]+$ ]] && [[ "$BACKUP_HEALTHCHECK_WINDOW" -ge 1 ]] \
-        || error "BACKUP_HEALTHCHECK_WINDOW må være et positivt heltall >= 1, fikk: '$BACKUP_HEALTHCHECK_WINDOW'"
 
     if [[ -n "$HETZNER_HOST" ]]; then
         [[ "$HETZNER_HOST" =~ ^[a-zA-Z0-9.-]+$ ]] || error "HETZNER_HOST inneholder ugyldige tegn: '$HETZNER_HOST'"

--- a/tests/check_requirements.bats
+++ b/tests/check_requirements.bats
@@ -164,3 +164,13 @@ teardown() {
     [ "$status" -ne 0 ]
     [[ "$output" == *"HETZNER_PORT"* ]]
 }
+
+@test "BACKUP_HEALTHCHECK_WINDOW ignoreres av entrypoint (eies av consumer docker-compose)" {
+    export PROJECT_NAME=testprosjekt
+    export DB_PASSWORD=hemmelig
+    export BACKUP_ENCRYPTION_KEY=nokkel
+    export BACKUP_HEALTHCHECK_WINDOW="ikke-et-tall"
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"BACKUP_HEALTHCHECK_WINDOW"* ]]
+}


### PR DESCRIPTION
Fixes #94

Dead code:  var definert og validert i entrypoint, men ble aldri brukt. Healthcheck-vinduet eies av consumer-appens docker-compose.

- Fjernet definisjon og validering fra 
- Oppdatert README og CLAUDE.md
- Lagt til test som verifiserer at variabelen ikke lenger valideres