### PR TITLE
fix: stopp backup-container crash-loop (ikke-fatal Hetzner-cleanup + BusyBox-dato)

### DIFF
--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -163,8 +163,12 @@ cleanup_hetzner() {
     fi
 
     log "Rydder gamle backups pa Hetzner StorageBox..."
-    local cutoff_ts
-    cutoff_ts=$(date -d "-${BACKUP_RETENTION_DAYS} days" +%Y%m%d 2>/dev/null || date -v-"${BACKUP_RETENTION_DAYS}"d +%Y%m%d 2>/dev/null || echo "")
+    local cutoff_ts cutoff_epoch
+    # BusyBox (Alpine) date stotter verken GNU "-d '-N days'" eller BSD "-v-Nd".
+    # Beregn cutoff via epoke-aritmetikk og formater med "-d @EPOCH" (virker pa
+    # bade BusyBox og GNU); BSD "-r" som fallback.
+    cutoff_epoch=$(( $(date +%s) - BACKUP_RETENTION_DAYS * 86400 ))
+    cutoff_ts=$(date -d "@${cutoff_epoch}" +%Y%m%d 2>/dev/null || date -r "${cutoff_epoch}" +%Y%m%d 2>/dev/null || echo "")
     [[ -z "$cutoff_ts" ]] && { log "ADVARSEL: Klarte ikke beregne dato-cutoff for Hetzner cleanup — sjekk BACKUP_RETENTION_DAYS='${BACKUP_RETENTION_DAYS}'"; return 1; }
 
     local files_to_delete=()
@@ -254,8 +258,9 @@ run_backup() {
     # Slett lokale backups eldre enn BACKUP_RETENTION_DAYS
     cleanup_local "sql.gz"
 
-    # Slett gamle backups pa Hetzner
-    cleanup_hetzner
+    # Slett gamle backups pa Hetzner (best-effort — opprydding ma ALDRI avbryte
+    # backup-flyten eller hindre at cron-daemonen starter via set -e)
+    cleanup_hetzner || log "ADVARSEL: Hetzner-opprydding feilet — fortsetter (lokal backup er intakt)"
 
     log "Backup fullfort OK"
 }


### PR DESCRIPTION
## Problem
`hwa-prod-backup-1` (6810s prod-DB-backup) sto i en **permanent restart-loop** (70 restarts, «Container-churn»-alarm 01.06 06:30). Den kjørte initial-backup hvert ~40s og nådde **aldri** `exec crond` → ingen planlagte backups, kun gjentatt initial-backup.

## Rotårsak
`run_backup()` kalte `cleanup_hetzner` **uguardet** under `set -euo pipefail`. `cleanup_hetzner` returnerte 1 fordi dato-cutoff brukte `date -d "-N days"` / `date -v-Nd` — **ingen av dem støttes av BusyBox (Alpine) date** → tom cutoff → `return 1` → `set -e` drepte hele skriptet *før* cron-oppsettet. Siden offsite-opplastingen til denne StorageBox-en alltid feiler, crashet containeren hver runde.

## Fiks
- `cleanup_hetzner`: beregn cutoff via epoke-aritmetikk, formater med `date -d @EPOCH` (virker på både BusyBox og GNU; BSD `-r` som fallback). Verifisert på `postgres:16.14-alpine`: `date -d @EPOCH` → `20260502`, original → `invalid date`.
- `run_backup`: guard `cleanup_hetzner`-kallet — best-effort opprydding skal ALDRI avbryte backup-flyten eller hindre at cron-daemonen starter.

## Verifisert
Bygget om 6810 backup-image: containeren nnår nå «Starter cron daemon», `RestartCount=0`, og Hetzner-feil logges som ikke-fatale advarsler («Lokal backup er intakt») som designet.

## Gjenstår (egen issue)
Offsite-opplasting til `u571604` feiler fortsatt — StorageBox avviser `ssh host <cmd>` ("Command not found. Use 'help'"). Spores separat.