### PR TITLE
Fix #100: SFTP-only StorageBox support (bytt ssh-kommandoer med sftp batch)

### DIFF
--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -42,7 +42,8 @@ HETZNER_BACKUP_PATH="${HETZNER_BACKUP_PATH:-backups/${PROJECT_NAME}}"
 
 # SSH-nokkel via mktemp (ryddes opp via trap)
 SSH_KEY=$(mktemp)
-SSH_OPTS=(-i "${SSH_KEY}" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -p "${HETZNER_PORT}")
+# sftp bruker -P (stor bokstav) for port, -q for stille modus
+SFTP_OPTS=(-q -i "${SSH_KEY}" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -P "${HETZNER_PORT}")
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"; }
 error() { log "ERROR: $1" >&2; exit 1; }
@@ -115,22 +116,19 @@ upload_to_hetzner() {
 
     log "Laster opp til Hetzner StorageBox ($HETZNER_HOST)..."
 
-    # Opprett mapper hvis de ikke finnes (ett niva om gangen - Hetzner stotter ikke mkdir -p)
+    # Opprett mapper hvis de ikke finnes (ett nivå om gangen — Hetzner støtter ikke mkdir -p).
+    # Bruker SFTP batch: -mkdir (med bindestrek) er non-fatal og feiler stille om katalogen
+    # allerede finnes; ls uten bindestrek verifiserer at katalogen eksisterer etter forsøket.
     local path_parts
     IFS='/' read -ra path_parts <<< "${HETZNER_BACKUP_PATH}"
     local current_path=""
     for part in "${path_parts[@]}"; do
         [[ -z "$part" ]] && continue
         current_path="${current_path:+${current_path}/}${part}"
-        # shellcheck disable=SC2029 # lokal ekspansjon tilsiktet — verdier validert i check_requirements()
-        ssh "${SSH_OPTS[@]}" "${HETZNER_USER}@${HETZNER_HOST}" mkdir "${current_path}" 2>/dev/null \
-            || ssh "${SSH_OPTS[@]}" "${HETZNER_USER}@${HETZNER_HOST}" test -d "${current_path}" \
+        printf -- '-mkdir %s\nls %s\n' "${current_path}" "${current_path}" \
+            | sftp "${SFTP_OPTS[@]}" "${HETZNER_USER}@${HETZNER_HOST}" >/dev/null 2>&1 \
             || { log "ADVARSEL: Kan ikke opprette eller bekrefte katalog '${current_path}' på Hetzner"; return 1; }
     done
-
-    # Generer checksum for verifisering etter opplasting
-    local local_sha256
-    local_sha256=$(sha256sum "$backup_file" | cut -d' ' -f1)
 
     if ! scp -P "${HETZNER_PORT}" -i "${SSH_KEY}" \
         -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
@@ -140,19 +138,21 @@ upload_to_hetzner() {
         return 1
     fi
 
-    # Verifiser checksum pa Hetzner
-    local remote_sha256
-    # shellcheck disable=SC2029 # lokal ekspansjon tilsiktet — verdier validert i check_requirements()
-    remote_sha256=$(ssh "${SSH_OPTS[@]}" "${HETZNER_USER}@${HETZNER_HOST}" \
-        sha256sum "${HETZNER_BACKUP_PATH}/${filename}" 2>/dev/null | cut -d' ' -f1 || echo "")
+    # Verifiser opplastet fil via SFTP ls -la (sha256sum ikke tilgjengelig i SFTP-only modus).
+    # Sammenligner filstørrelse lokalt vs. på Hetzner.
+    local local_size remote_size
+    local_size=$(wc -c < "$backup_file")
+    remote_size=$(printf 'ls -la %s/%s\n' "${HETZNER_BACKUP_PATH}" "${filename}" \
+        | sftp "${SFTP_OPTS[@]}" "${HETZNER_USER}@${HETZNER_HOST}" 2>/dev/null \
+        | awk 'NF >= 9 && /^[-dl]/ {print $5}' | grep -E '^[0-9]+$' | head -1 || echo "")
 
-    if [[ "$local_sha256" == "$remote_sha256" ]]; then
-        log "Offsite backup lastet opp og verifisert: ${HETZNER_BACKUP_PATH}/${filename}"
-    elif [[ -z "$remote_sha256" ]]; then
-        log "ADVARSEL: Kunne ikke verifisere checksum på Hetzner (sha256sum utilgjengelig) — regnes som opplastingsfeil"
+    if [[ -n "$remote_size" ]] && [[ "$remote_size" -eq "$local_size" ]]; then
+        log "Offsite backup lastet opp og verifisert (${remote_size} bytes): ${HETZNER_BACKUP_PATH}/${filename}"
+    elif [[ -z "$remote_size" ]]; then
+        log "ADVARSEL: Kunne ikke bekrefte opplastet fil på Hetzner — regnes som opplastingsfeil"
         return 1
     else
-        log "ADVARSEL: Checksum-mismatch etter opplasting! Lokal=$local_sha256 Remote=$remote_sha256"
+        log "ADVARSEL: Størrelsesmismatch etter opplasting! Lokal=${local_size} Remote=${remote_size}"
         return 1
     fi
 }
@@ -172,7 +172,6 @@ cleanup_hetzner() {
     [[ -z "$cutoff_ts" ]] && { log "ADVARSEL: Klarte ikke beregne dato-cutoff for Hetzner cleanup — sjekk BACKUP_RETENTION_DAYS='${BACKUP_RETENTION_DAYS}'"; return 1; }
 
     local files_to_delete=()
-    # shellcheck disable=SC2029 # lokal ekspansjon tilsiktet — verdier validert i check_requirements()
     while read -r remote_file; do
         if [[ ! "$remote_file" =~ ^[a-zA-Z0-9._-]+$ ]]; then
             log "ADVARSEL: Avvist filnavn med ugyldige tegn: $remote_file"
@@ -184,13 +183,18 @@ cleanup_hetzner() {
             log "Markerer for sletting: $remote_file"
             files_to_delete+=("${HETZNER_BACKUP_PATH}/${remote_file}")
         fi
-    done < <(ssh "${SSH_OPTS[@]}" "${HETZNER_USER}@${HETZNER_HOST}" ls "${HETZNER_BACKUP_PATH}" 2>/dev/null)
+    done < <(printf 'ls -la %s\n' "${HETZNER_BACKUP_PATH}" \
+        | sftp "${SFTP_OPTS[@]}" "${HETZNER_USER}@${HETZNER_HOST}" 2>/dev/null \
+        | awk 'NF >= 9 && /^[-dl]/ && $NF !~ /^\.$|^\.\.$/ {print $NF}')
 
     if [[ ${#files_to_delete[@]} -gt 0 ]]; then
         log "Sletter ${#files_to_delete[@]} gammel(e) offsite backup(s)..."
-        # shellcheck disable=SC2029 # lokal ekspansjon tilsiktet — verdier validert i check_requirements()
-        ssh "${SSH_OPTS[@]}" "${HETZNER_USER}@${HETZNER_HOST}" \
-            rm "${files_to_delete[@]}" \
+        local sftp_rm_batch=""
+        for f in "${files_to_delete[@]}"; do
+            sftp_rm_batch+="rm ${f}"$'\n'
+        done
+        printf '%s' "$sftp_rm_batch" \
+            | sftp "${SFTP_OPTS[@]}" "${HETZNER_USER}@${HETZNER_HOST}" >/dev/null 2>&1 \
             || log "ADVARSEL: Sletting av gamle Hetzner-backups feilet — filer kan akkumulere"
     fi
 }

--- a/tests/hetzner_cleanup.bats
+++ b/tests/hetzner_cleanup.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
 #
 # Tester for cleanup_hetzner() i backup-entrypoint.sh.
-# Verifiserer at sletting av gamle Hetzner-backups gjøres med én SSH rm-kommando
-# uansett antall filer (ikke N+1 SSH-tilkoblinger).
+# Verifiserer at sletting av gamle Hetzner-backups gjøres via SFTP batch
+# med minimalt antall sftp-prosess-kall.
 
 load 'helpers/common'
 
@@ -18,15 +18,15 @@ setup() {
     export HETZNER_USER=u12345
     export BACKUP_RETENTION_DAYS=30
 
-    STUB_SSH_CALL_LOG="$(mktemp)"
-    export STUB_SSH_CALL_LOG
+    STUB_SFTP_CALL_LOG="$(mktemp)"
+    export STUB_SFTP_CALL_LOG
 
-    unset STUB_SCP_FAIL STUB_SSH_FAIL STUB_SSH_LS_OUTPUT
+    unset STUB_SCP_FAIL STUB_SFTP_FAIL STUB_SFTP_LS_OUTPUT STUB_SFTP_RM_FAIL
 }
 
 teardown() {
     rm -rf "$BACKUP_DIR"
-    rm -f "${STUB_SSH_CALL_LOG:-}"
+    rm -f "${STUB_SFTP_CALL_LOG:-}"
 }
 
 # Laster backup-entrypoint.sh som bibliotek uten main og uten set -euo pipefail
@@ -39,61 +39,78 @@ load_backup_lib() {
     echo "dummy-ssh-key" > "$SSH_KEY"
 }
 
-@test "cleanup_hetzner gjør maks 2 SSH-kall (ls + rm) for 3 gamle filer" {
+# ls -la-formatert linje (permissions links owner group size month day time name)
+ls_la_line() {
+    echo "-rw-r--r--    1 u12345  u12345      12345 Jan  1 2020 ${1}"
+}
+
+# Teller antall sftp-prosess-invokasjonar (linjer uten CMD:-prefiks i CALL_LOG)
+sftp_process_count() {
+    grep -v '^CMD:' "$STUB_SFTP_CALL_LOG" 2>/dev/null | wc -l | tr -d ' '
+}
+
+@test "cleanup_hetzner gjoor maks 2 SFTP-prosess-kall (ls-la + rm) for 3 gamle filer" {
     # Cutoff blir i dag - 30 dager; filer fra 2020 er garantert eldre
-    export STUB_SSH_LS_OUTPUT="testprosjekt_20200101_030000.sql.gz.gpg
-testprosjekt_20200102_030000.sql.gz.gpg
-testprosjekt_20200103_030000.sql.gz.gpg"
+    local l1 l2 l3
+    l1=$(ls_la_line "testprosjekt_20200101_030000.sql.gz.gpg")
+    l2=$(ls_la_line "testprosjekt_20200102_030000.sql.gz.gpg")
+    l3=$(ls_la_line "testprosjekt_20200103_030000.sql.gz.gpg")
+    export STUB_SFTP_LS_OUTPUT="${l1}"$'\n'"${l2}"$'\n'"${l3}"
 
     load_backup_lib
     run cleanup_hetzner
 
     local call_count
-    call_count=$(wc -l < "$STUB_SSH_CALL_LOG")
+    call_count=$(sftp_process_count)
     [[ "$call_count" -le 2 ]]
 }
 
-@test "cleanup_hetzner gjør ingen rm-kall hvis ingen filer er eldre enn cutoff" {
+@test "cleanup_hetzner gjoor ingen rm-kall hvis ingen filer er eldre enn cutoff" {
     # Filer fra fremtiden er garantert nyere enn cutoff
     local future_date
     future_date=$(date -d "+365 days" +%Y%m%d 2>/dev/null || date -v+365d +%Y%m%d 2>/dev/null || echo "20991231")
-    export STUB_SSH_LS_OUTPUT="testprosjekt_${future_date}_030000.sql.gz.gpg"
+    export STUB_SFTP_LS_OUTPUT="$(ls_la_line "testprosjekt_${future_date}_030000.sql.gz.gpg")"
 
     load_backup_lib
     run cleanup_hetzner
 
-    # Kun ls-kallet forventes — ingen rm
-    ! grep -q ' rm ' "$STUB_SSH_CALL_LOG" 2>/dev/null
+    # Kun ls-la-kallet forventes — ingen rm
+    ! grep -q '^CMD: rm ' "$STUB_SFTP_CALL_LOG" 2>/dev/null
 }
 
-@test "cleanup_hetzner gjør ingen SSH-kall når Hetzner ikke er konfigurert" {
+@test "cleanup_hetzner gjoor ingen SFTP-kall naaar Hetzner ikke er konfigurert" {
     unset HETZNER_HOST
 
     load_backup_lib
     run cleanup_hetzner
 
     local call_count
-    call_count=$(wc -l < "$STUB_SSH_CALL_LOG")
+    call_count=$(sftp_process_count)
     [[ "$call_count" -eq 0 ]]
 }
 
 @test "cleanup_hetzner avviser filnavn med spesialtegn og logger advarsel" {
-    export STUB_SSH_LS_OUTPUT="testprosjekt_20200101_030000.sql.gz.gpg
-testprosjekt_20200102_030000.sql.gz.gpg;rm -rf /
-testprosjekt_20200103_030000.sql.gz.gpg"
+    # Filnavn med semikolon (injeksjonsforsøk) skal avvises.
+    # Bruker variabel for å unngå at semikolon tolkes av shell i command substitution.
+    local malicious="testprosjekt_20200102_030000.sql.gz.gpg;malicious"
+    local l1 l2 l3
+    l1=$(ls_la_line "testprosjekt_20200101_030000.sql.gz.gpg")
+    l2="-rw-r--r--    1 u12345  u12345      12345 Jan  2 2020 ${malicious}"
+    l3=$(ls_la_line "testprosjekt_20200103_030000.sql.gz.gpg")
+    export STUB_SFTP_LS_OUTPUT="${l1}"$'\n'"${l2}"$'\n'"${l3}"
 
     load_backup_lib
     run cleanup_hetzner
 
     # Filen med semikolon skal ikke være med i rm-kommandoen
-    ! grep -q 'rm.*rm -rf' "$STUB_SSH_CALL_LOG" 2>/dev/null
+    ! grep -q 'malicious' "$STUB_SFTP_CALL_LOG" 2>/dev/null
     # Advarsel skal være logget
     echo "$output" | grep -q "ADVARSEL"
 }
 
-@test "cleanup_hetzner logger advarsel naar SSH rm-kommando feiler" {
-    export STUB_SSH_LS_OUTPUT="testprosjekt_20200101_030000.sql.gz.gpg"
-    export STUB_SSH_RM_FAIL=1
+@test "cleanup_hetzner logger advarsel naaar SFTP rm-kommando feiler" {
+    export STUB_SFTP_LS_OUTPUT="$(ls_la_line "testprosjekt_20200101_030000.sql.gz.gpg")"
+    export STUB_SFTP_RM_FAIL=1
 
     load_backup_lib
     run cleanup_hetzner
@@ -102,17 +119,19 @@ testprosjekt_20200103_030000.sql.gz.gpg"
 }
 
 @test "cleanup_hetzner behandler gyldige filnavn normalt" {
-    export STUB_SSH_LS_OUTPUT="testprosjekt_20200101_030000.sql.gz.gpg
-testprosjekt_20200102_030000.sql.gz.gpg"
+    local l1 l2
+    l1=$(ls_la_line "testprosjekt_20200101_030000.sql.gz.gpg")
+    l2=$(ls_la_line "testprosjekt_20200102_030000.sql.gz.gpg")
+    export STUB_SFTP_LS_OUTPUT="${l1}"$'\n'"${l2}"
 
     load_backup_lib
     run cleanup_hetzner
 
     # Begge filer skal markeres for sletting (rm-kall skal forekomme)
-    grep -q ' rm ' "$STUB_SSH_CALL_LOG" 2>/dev/null
+    grep -q '^CMD: rm ' "$STUB_SFTP_CALL_LOG" 2>/dev/null
 }
 
-@test "cleanup_hetzner returnerer feil og logger advarsel naar dato-cutoff-kalkulasjon feiler" {
+@test "cleanup_hetzner returnerer feil og logger advarsel naaar dato-cutoff-kalkulasjon feiler" {
     export STUB_DATE_FAIL=1
 
     load_backup_lib
@@ -125,10 +144,10 @@ testprosjekt_20200102_030000.sql.gz.gpg"
 @test "cleanup_hetzner sletter gammel fil — dato-ekstraksjon med POSIX sed (BusyBox-kompatibel)" {
     # grep -oP (Perl-regex) støttes ikke i BusyBox grep (postgres:16-alpine).
     # Verifiserer at dato-ekstraksjon fungerer og at filen inkluderes i rm-kommandoen.
-    export STUB_SSH_LS_OUTPUT="testprosjekt_20200101_030000.sql.gz.gpg"
+    export STUB_SFTP_LS_OUTPUT="$(ls_la_line "testprosjekt_20200101_030000.sql.gz.gpg")"
 
     load_backup_lib
     run cleanup_hetzner
 
-    grep -q 'testprosjekt_20200101_030000.sql.gz.gpg' "$STUB_SSH_CALL_LOG"
+    grep -q 'testprosjekt_20200101_030000.sql.gz.gpg' "$STUB_SFTP_CALL_LOG"
 }

--- a/tests/hetzner_retry.bats
+++ b/tests/hetzner_retry.bats
@@ -21,7 +21,7 @@ setup() {
     export HETZNER_HOST=hetzner.example
     export HETZNER_USER=u12345
 
-    unset STUB_SCP_FAIL STUB_SSH_FAIL
+    unset STUB_SCP_FAIL STUB_SSH_FAIL STUB_SFTP_FAIL STUB_SFTP_WRONG_SIZE STUB_SFTP_LS_SIZE
 }
 
 teardown() {
@@ -62,8 +62,8 @@ load_backup_lib() {
     [[ "$output" == *"Hetzner-opplasting feilet etter 3 forsok"* ]]
 }
 
-@test "upload_with_retry prover pa nytt ved checksum-mismatch etter opplasting" {
-    export STUB_SSH_WRONG_CHECKSUM=1
+@test "upload_with_retry prover pa nytt ved stoerrelses-mismatch etter opplasting" {
+    export STUB_SFTP_WRONG_SIZE=1
     export BACKUP_RETRY_MAX=3
     load_backup_lib
 
@@ -71,12 +71,14 @@ load_backup_lib() {
     echo "content" > "$dummy"
 
     run upload_with_retry "$dummy"
-    [[ "$output" == *"Checksum-mismatch"* ]]
+    [[ "$output" == *"Størrelsesmismatch"* ]]
     [[ "$output" == *"forsok 1/3"* ]]
     [[ "$output" == *"forsok 2/3"* ]]
 }
 
-@test "upload_to_hetzner logger advarsel og returnerer 1 ved tom sha256sum-respons" {
+@test "upload_to_hetzner logger advarsel og returnerer 1 naar SFTP ls -la ikke returnerer filinfo" {
+    # STUB_SFTP_LS_EMPTY=1: ls -la returnerer ingenting → remote_size="" → "Kunne ikke bekrefte"
+    export STUB_SFTP_LS_EMPTY=1
     load_backup_lib
 
     local dummy="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
@@ -84,11 +86,11 @@ load_backup_lib() {
 
     run upload_to_hetzner "$dummy"
     [ "$status" -eq 1 ]
-    [[ "$output" == *"Kunne ikke verifisere checksum"* ]]
+    [[ "$output" == *"Kunne ikke bekrefte"* ]]
 }
 
-@test "upload_to_hetzner returnerer 1 og logger katalog-feil naar mkdir og test-d begge feiler paa Hetzner" {
-    export STUB_SSH_FAIL=1
+@test "upload_to_hetzner returnerer 1 og logger katalog-feil naar SFTP-tilkobling feiler" {
+    export STUB_SFTP_FAIL=1
     load_backup_lib
 
     local dummy="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
@@ -126,8 +128,8 @@ load_backup_lib() {
     [[ "$output" != *"forsok 2/2"* ]]
 }
 
-@test "upload_to_hetzner returnerer 1 og logger katalog-feil ved SSH permission denied (STUB_SSH_EXIT=permission_denied)" {
-    export STUB_SSH_EXIT=permission_denied
+@test "upload_to_hetzner returnerer 1 og logger katalog-feil ved SFTP-tilkoblingsfeil" {
+    export STUB_SFTP_FAIL=1
     load_backup_lib
 
     local dummy="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
@@ -138,14 +140,19 @@ load_backup_lib() {
     [[ "$output" == *"katalog"* ]]
 }
 
-@test "upload_to_hetzner returnerer 1 og logger katalog-feil ved SSH timeout (STUB_SSH_EXIT=timeout, exit 255)" {
-    export STUB_SSH_EXIT=timeout
+@test "upload_to_hetzner lykkes i SFTP-only-modus (ssh feiler, sftp fungerer)" {
+    # Simuler StorageBox i SFTP-only-modus: ssh er utilgjengelig, sftp virker.
+    # Med gammel kode (ssh mkdir/test-d) feiler upload_to_hetzner.
+    # Med ny kode (sftp -mkdir/ls) skal upload lykkes.
+    export STUB_SSH_FAIL=1
+    export STUB_SFTP_FAIL=0
     load_backup_lib
 
     local dummy="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
-    echo "content" > "$dummy"
+    printf 'content' > "$dummy"
+    export STUB_SFTP_LS_SIZE=7
 
     run upload_to_hetzner "$dummy"
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"katalog"* ]]
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"lastet opp og verifisert"* ]]
 }

--- a/tests/run_backup.bats
+++ b/tests/run_backup.bats
@@ -113,10 +113,10 @@ load_backup_lib() {
     [[ "$output" == *"forsok"* ]]
 }
 
-@test "run_backup logger ADVARSEL og katalog-feil ved SSH permission denied paa Hetzner mkdir (lokal backup ok)" {
+@test "run_backup logger ADVARSEL og katalog-feil ved SFTP-tilkoblingsfeil paa Hetzner mkdir (lokal backup ok)" {
     export HETZNER_HOST=hetzner.example
     export HETZNER_USER=u12345
-    export STUB_SSH_EXIT=permission_denied
+    export STUB_SFTP_FAIL=1
     export BACKUP_RETRY_MAX=1
     load_backup_lib
 

--- a/tests/stubs/sftp
+++ b/tests/stubs/sftp
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Stub for sftp i batch-modus (-b -).
+# Leser SFTP-kommandoer fra stdin og simulerer respons.
+#
+# Støttede env-variabler:
+#   STUB_SFTP_FAIL=1          - tilkoblingsfeil (exit 1 umiddelbart)
+#   STUB_SFTP_MKDIR_FAIL=1    - mkdir-kommandoer feiler (uten - prefix → exit 1)
+#   STUB_SFTP_LS_OUTPUT       - rå ls-la-formatert output for ls-la-kommandoer
+#   STUB_SFTP_LS_SIZE         - filstørrelse som returneres for ls-la-enkeltfil (default: 7)
+#   STUB_SFTP_LS_EMPTY=1      - ls -la returnerer ingen output (verifisering feiler)
+#   STUB_SFTP_WRONG_SIZE=1    - returnerer feil størrelse (for å simulere størrelsesmismatch)
+#   STUB_SFTP_RM_FAIL=1       - rm-kommandoer feiler (exit 1)
+#   STUB_SFTP_CALL_LOG        - fil for å logge sftp-prosess-kall (én linje per prosess-invokasjon)
+
+[[ "${STUB_SFTP_FAIL:-0}" == "1" ]] && exit 1
+
+if [[ -n "${STUB_SFTP_CALL_LOG:-}" ]]; then
+    echo "$*" >> "$STUB_SFTP_CALL_LOG"
+fi
+
+# Les batch-kommandoer fra stdin
+while IFS= read -r cmd; do
+    [[ -z "$cmd" ]] && continue
+
+    # Strip evt. ledende '-' (non-fatal prefix)
+    bare_cmd="${cmd#-}"
+
+    if [[ -n "${STUB_SFTP_CALL_LOG:-}" ]]; then
+        echo "CMD: ${bare_cmd}" >> "$STUB_SFTP_CALL_LOG"
+    fi
+
+    case "${bare_cmd%% *}" in
+        mkdir)
+            if [[ "${STUB_SFTP_MKDIR_FAIL:-0}" == "1" ]] && [[ "$cmd" != "-"* ]]; then
+                exit 1
+            fi
+            ;;
+        ls)
+            if [[ "$bare_cmd" == "ls -la "* ]]; then
+                # ls -la for upload-verifisering eller cleanup-listing
+                if [[ "${STUB_SFTP_LS_EMPTY:-0}" == "1" ]]; then
+                    : # returner ingenting — remote_size blir tom → "Kunne ikke bekrefte"
+                elif [[ -n "${STUB_SFTP_LS_OUTPUT:-}" ]]; then
+                    echo "${STUB_SFTP_LS_OUTPUT}"
+                else
+                    local_file="${bare_cmd#ls -la }"
+                    filename="${local_file##*/}"
+                    if [[ "${STUB_SFTP_WRONG_SIZE:-0}" == "1" ]]; then
+                        size=999999
+                    else
+                        size="${STUB_SFTP_LS_SIZE:-7}"
+                    fi
+                    echo "-rw-r--r--    1 u12345  u12345       ${size} Jun  1 03:00 ${filename}"
+                fi
+            elif [[ "$bare_cmd" == "ls "* ]]; then
+                [[ -n "${STUB_SFTP_LS_OUTPUT:-}" ]] && echo "${STUB_SFTP_LS_OUTPUT}"
+            fi
+            ;;
+        rm)
+            if [[ "${STUB_SFTP_RM_FAIL:-0}" == "1" ]]; then
+                exit 1
+            fi
+            ;;
+    esac
+done
+
+exit 0


### PR DESCRIPTION
Fixes #100

## Endringer

Erstatter alle `ssh host <cmd>`-kall med `sftp -b` (batch-modus) for Hetzner StorageBox-operasjoner:

- **Katalogopprettelse**: `sftp -mkdir/ls` istedenfor `ssh mkdir/test -d`
- **Opplastingsverifisering**: `sftp ls -la` størrelsesjekk istedenfor `ssh sha256sum` (ikke tilgjengelig i SFTP-only)
- **Oppryddingslistning**: `sftp ls -la | awk` istedenfor `ssh ls`
- **Oppryddingssletting**: `sftp` batch `rm` istedenfor `ssh rm`

## Bakoverkompatibilitet

SFTP fungerer uavhengig av «SSH support»-toggle i Hetzner Robot. `biologportal` mot `u554595` berøres ikke.

## Tester

- Ny `tests/stubs/sftp`-stub med støtte for STUB_SFTP_FAIL, STUB_SFTP_LS_OUTPUT, STUB_SFTP_WRONG_SIZE, STUB_SFTP_LS_EMPTY, STUB_SFTP_RM_FAIL, STUB_SFTP_CALL_LOG
- Oppdatert `hetzner_retry.bats`, `hetzner_cleanup.bats`, `run_backup.bats`
- Ny test: «upload_to_hetzner lykkes i SFTP-only-modus (ssh feiler, sftp fungerer)»
- Alle 79 tester grønne