### PR TITLE
Fix #98: Pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Generate App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
         with:
           app-id: ${{ secrets.GRUNNMUR_APP_ID }}
           private-key: ${{ secrets.GRUNNMUR_APP_KEY }}


### PR DESCRIPTION
Fixes #98

Pins alle GitHub Actions til commit SHA for å forhindre supply chain-angrep.

## Endringer

- `actions/create-github-app-token@v3` → `@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3`

SHA er bekreftet via GitHub API — v3 er en lett tag som peker direkte til commit-SHA.

## Test

Ikke mulig å enhetsteste workflow-fil-endringer (BATS støtter ikke GitHub Actions-syntax). SHA-pinning verifiseres ved at workflow kjører korrekt i CI.