### PR TITLE
Fix: SSH shell fallback for Hetzner when SFTP subsystem unavailable

### DIFF
--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -44,6 +44,8 @@ HETZNER_BACKUP_PATH="${HETZNER_BACKUP_PATH:-backups/${PROJECT_NAME}}"
 SSH_KEY=$(mktemp)
 # sftp bruker -P (stor bokstav) for port, -q for stille modus
 SFTP_OPTS=(-q -i "${SSH_KEY}" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -P "${HETZNER_PORT}")
+# SSH_OPTS er fallback naar SFTP-subsystem er utilgjengelig (ssh bruker -p i stedet for -P)
+SSH_OPTS=(-i "${SSH_KEY}" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -p "${HETZNER_PORT}")
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"; }
 error() { log "ERROR: $1" >&2; exit 1; }
@@ -117,17 +119,22 @@ upload_to_hetzner() {
     log "Laster opp til Hetzner StorageBox ($HETZNER_HOST)..."
 
     # Opprett mapper hvis de ikke finnes (ett nivå om gangen — Hetzner støtter ikke mkdir -p).
-    # Bruker SFTP batch: -mkdir (med bindestrek) er non-fatal og feiler stille om katalogen
-    # allerede finnes; ls uten bindestrek verifiserer at katalogen eksisterer etter forsøket.
+    # Prøver SFTP batch først (for SFTP-only StorageBox); faller tilbake til SSH shell-kommandoer
+    # for StorageBox-kontoer der SFTP-subsystemet er utilgjengelig (f.eks. u571604).
     local path_parts
     IFS='/' read -ra path_parts <<< "${HETZNER_BACKUP_PATH}"
     local current_path=""
     for part in "${path_parts[@]}"; do
         [[ -z "$part" ]] && continue
         current_path="${current_path:+${current_path}/}${part}"
-        printf -- '-mkdir %s\nls %s\n' "${current_path}" "${current_path}" \
-            | sftp "${SFTP_OPTS[@]}" "${HETZNER_USER}@${HETZNER_HOST}" >/dev/null 2>&1 \
-            || { log "ADVARSEL: Kan ikke opprette eller bekrefte katalog '${current_path}' på Hetzner"; return 1; }
+        if ! printf -- '-mkdir %s\nls %s\n' "${current_path}" "${current_path}" \
+                | sftp "${SFTP_OPTS[@]}" "${HETZNER_USER}@${HETZNER_HOST}" >/dev/null 2>&1; then
+            # SFTP-subsystem utilgjengelig — fall tilbake til SSH shell-kommandoer
+            # shellcheck disable=SC2029
+            ssh "${SSH_OPTS[@]}" "${HETZNER_USER}@${HETZNER_HOST}" mkdir "${current_path}" 2>/dev/null \
+                || ssh "${SSH_OPTS[@]}" "${HETZNER_USER}@${HETZNER_HOST}" test -d "${current_path}" \
+                || { log "ADVARSEL: Kan ikke opprette eller bekrefte katalog '${current_path}' på Hetzner (SFTP og SSH feilet)"; return 1; }
+        fi
     done
 
     if ! scp -P "${HETZNER_PORT}" -i "${SSH_KEY}" \
@@ -138,8 +145,8 @@ upload_to_hetzner() {
         return 1
     fi
 
-    # Verifiser opplastet fil via SFTP ls -la (sha256sum ikke tilgjengelig i SFTP-only modus).
-    # Sammenligner filstørrelse lokalt vs. på Hetzner.
+    # Verifiser opplastet fil: SFTP ls -la (størrelses-sjekk) primært,
+    # SSH sha256sum som fallback når SFTP-subsystemet er utilgjengelig.
     local local_size remote_size
     local_size=$(wc -c < "$backup_file")
     remote_size=$(printf 'ls -la %s/%s\n' "${HETZNER_BACKUP_PATH}" "${filename}" \
@@ -148,12 +155,25 @@ upload_to_hetzner() {
 
     if [[ -n "$remote_size" ]] && [[ "$remote_size" -eq "$local_size" ]]; then
         log "Offsite backup lastet opp og verifisert (${remote_size} bytes): ${HETZNER_BACKUP_PATH}/${filename}"
-    elif [[ -z "$remote_size" ]]; then
-        log "ADVARSEL: Kunne ikke bekrefte opplastet fil på Hetzner — regnes som opplastingsfeil"
-        return 1
-    else
+    elif [[ -n "$remote_size" ]]; then
         log "ADVARSEL: Størrelsesmismatch etter opplasting! Lokal=${local_size} Remote=${remote_size}"
         return 1
+    else
+        # SFTP ls -la feilet — prøv SSH sha256sum som fallback
+        local local_sha256 remote_sha256
+        local_sha256=$(sha256sum "$backup_file" | cut -d' ' -f1)
+        # shellcheck disable=SC2029
+        remote_sha256=$(ssh "${SSH_OPTS[@]}" "${HETZNER_USER}@${HETZNER_HOST}" \
+            sha256sum "${HETZNER_BACKUP_PATH}/${filename}" 2>/dev/null | cut -d' ' -f1 || echo "")
+        if [[ -n "$remote_sha256" ]] && [[ "$remote_sha256" == "$local_sha256" ]]; then
+            log "Offsite backup lastet opp og verifisert (sha256 via SSH): ${HETZNER_BACKUP_PATH}/${filename}"
+        elif [[ -n "$remote_sha256" ]]; then
+            log "ADVARSEL: Checksum-mismatch etter opplasting! Lokal=$local_sha256 Remote=$remote_sha256"
+            return 1
+        else
+            # Verken SFTP eller SSH klarte å verifisere — stoler på at SCP exit 0 betyr vellykket opplasting
+            log "ADVARSEL: Kunne ikke bekrefte opplastet fil på Hetzner (SFTP og SSH feilet) — SCP exit 0, antar vellykket"
+        fi
     fi
 }
 

--- a/tests/hetzner_retry.bats
+++ b/tests/hetzner_retry.bats
@@ -76,21 +76,24 @@ load_backup_lib() {
     [[ "$output" == *"forsok 2/3"* ]]
 }
 
-@test "upload_to_hetzner logger advarsel og returnerer 1 naar SFTP ls -la ikke returnerer filinfo" {
-    # STUB_SFTP_LS_EMPTY=1: ls -la returnerer ingenting → remote_size="" → "Kunne ikke bekrefte"
+@test "upload_to_hetzner logger advarsel men lykkes naar SFTP ls-la er tom og SSH sha256sum ogsaa er tom" {
+    # SFTP ls -la returnerer ingenting → SSH sha256sum fallback → ssh stub returnerer 0 med tom output
+    # Resultat: advarsel-logging, men status 0 (stoler paa SCP exit 0)
     export STUB_SFTP_LS_EMPTY=1
     load_backup_lib
 
     local dummy="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
-    echo "content" > "$dummy"
+    printf 'content' > "$dummy"
 
     run upload_to_hetzner "$dummy"
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 0 ]
     [[ "$output" == *"Kunne ikke bekrefte"* ]]
 }
 
-@test "upload_to_hetzner returnerer 1 og logger katalog-feil naar SFTP-tilkobling feiler" {
+@test "upload_to_hetzner returnerer 1 og logger katalog-feil naar baade SFTP og SSH feiler" {
+    # Bade SFTP og SSH maa feile for at katalog-oppretting skal returnere 1
     export STUB_SFTP_FAIL=1
+    export STUB_SSH_FAIL=1
     load_backup_lib
 
     local dummy="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
@@ -128,8 +131,9 @@ load_backup_lib() {
     [[ "$output" != *"forsok 2/2"* ]]
 }
 
-@test "upload_to_hetzner returnerer 1 og logger katalog-feil ved SFTP-tilkoblingsfeil" {
+@test "upload_to_hetzner returnerer 1 og logger katalog-feil naar baade SFTP og SSH feiler (2)" {
     export STUB_SFTP_FAIL=1
+    export STUB_SSH_FAIL=1
     load_backup_lib
 
     local dummy="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
@@ -138,6 +142,24 @@ load_backup_lib() {
     run upload_to_hetzner "$dummy"
     [ "$status" -eq 1 ]
     [[ "$output" == *"katalog"* ]]
+}
+
+@test "upload_to_hetzner lykkes med SSH-fallback naar SFTP-subsystem er utilgjengelig men SSH shell virker" {
+    # Simuler StorageBox der SFTP-subsystem feiler (f.eks. u571604 der SFTP er utilgjengelig)
+    # men SSH shell-kommandoer (mkdir/test-d) fungerer.
+    # Skal lykkes selv om hverken SFTP mkdir eller SFTP ls-la-verifisering virker.
+    export STUB_SFTP_FAIL=1
+    export STUB_SSH_FAIL=0
+    load_backup_lib
+
+    local dummy="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
+    printf 'content' > "$dummy"
+
+    run upload_to_hetzner "$dummy"
+    [ "$status" -eq 0 ]
+    # Forventer enten "lastet opp og verifisert" (SSH sha256sum fungerte) eller
+    # "Kunne ikke bekrefte" med SCP exit 0 (begge verifiseringsveier feiler, men OK)
+    [[ "$output" != *"SFTP og SSH feilet"* ]] || [[ "$output" == *"Kunne ikke bekrefte"* ]]
 }
 
 @test "upload_to_hetzner lykkes i SFTP-only-modus (ssh feiler, sftp fungerer)" {

--- a/tests/run_backup.bats
+++ b/tests/run_backup.bats
@@ -113,7 +113,10 @@ load_backup_lib() {
     [[ "$output" == *"forsok"* ]]
 }
 
-@test "run_backup logger ADVARSEL og katalog-feil ved SFTP-tilkoblingsfeil paa Hetzner mkdir (lokal backup ok)" {
+@test "run_backup lykkes med SSH-fallback og logger ADVARSEL naar SFTP feiler men SSH virker (lokal backup ok)" {
+    # SFTP-subsystem utilgjengelig (STUB_SFTP_FAIL=1), men SSH shell-kommandoer virker.
+    # SSH mkdir fallback oppretter katalog; SFTP-verifisering feiler; SSH sha256sum er tom.
+    # Lokal backup er OK, opplasting til Hetzner anses som vellykket (SCP exit 0).
     export HETZNER_HOST=hetzner.example
     export HETZNER_USER=u12345
     export STUB_SFTP_FAIL=1
@@ -123,7 +126,8 @@ load_backup_lib() {
     run run_backup
     [ "$status" -eq 0 ]
     [[ "$output" == *"ADVARSEL"* ]]
-    [[ "$output" == *"katalog"* ]]
+    # Med SSH-fallback: SSH mkdir virker stille; verifiseringen logger "Kunne ikke bekrefte"
+    [[ "$output" == *"Kunne ikke bekrefte"* ]]
 
     local files
     files=$(find "$BACKUP_DIR" -maxdepth 1 -name "testprosjekt_*.sql.gz.gpg" | wc -l)


### PR DESCRIPTION
## Sammendrag

Gjenoppretter Hetzner offsite-backup for 6810 (u571604) som ble brutt av commit b58811e (2026-06-01).

### Rotårsak

b58811e byttet SSH shell-kommandoer til ren SFTP batch-modus for å støtte SFTP-only StorageBox (issue #100). Men u571604 (6810) har SFTP-subsystemet utilgjengelig — sftp-klienten faller tilbake til Hetzner management shell som svarer `Command not found`. Siste vellykkede offsite-backup: 2026-06-01 02:00 (gammel kode). Alle backup-forsøk siden 14:08 samme dag har feilet.

### Endringer

- **Directory creation**: prøver SFTP mkdir/ls batch først, faller tilbake til SSH shell `mkdir`/`test -d` ved SFTP-feil
- **Upload verification**: hvis SFTP ls -la feiler (tom `remote_size`), faller tilbake til SSH `sha256sum`; hvis begge feiler, stoler på SCP exit 0 (log advarsel, ikke feil)
- **Backward compatible**: biologportal (u554595) fungerer uendret med SFTP-primær-veien; 6810 (u571604) bruker SSH-fallback

### Testing

- 80/80 BATS-tester grønne
- Nye tester: SSH-fallback-scenario (SFTP feiler, SSH virker), begge feiler
- Oppdaterte tester: eksisterende som forventer failure-ved-SFTP-fail krever nå at SSH også feiler

Fixes TommySkogstad/misc-scripts#867

🤖 Generated with [Claude Code](https://claude.com/claude-code)