### PR TITLE
Fix #109: add flock-based lock to prevent parallel backup runs

### DIFF
--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -30,6 +30,7 @@ BACKUP_RETRY_DELAY="${BACKUP_RETRY_DELAY:-5}"
 # Interne fil-stier (kan overstyres i tester via env-variabler)
 SAFEKEEPER_ENV_FILE="${SAFEKEEPER_ENV_FILE:-/etc/safekeeper.env}"
 CRONTAB_FILE="${CRONTAB_FILE:-/etc/crontabs/root}"
+BACKUP_LOCK_FILE="${BACKUP_LOCK_FILE:-/tmp/safekeeper-${PROJECT_NAME}.lock}"
 
 # Fil-backup (valgfritt)
 FILES_DIR="${FILES_DIR:-}"
@@ -354,6 +355,12 @@ main() {
     check_requirements
     setup_pgpass
     mkdir -p "$BACKUP_DIR"
+
+    exec {LOCK_FD}>"$BACKUP_LOCK_FILE"
+    if ! flock -xn "$LOCK_FD"; then
+        log "ADVARSEL: En backup kjores allerede (${BACKUP_LOCK_FILE}) — avslutter"
+        exit 0
+    fi
 
     if [[ "${1:-}" == "backup" ]]; then
         run_backup

--- a/tests/locking.bats
+++ b/tests/locking.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+#
+# Tester for lås mot parallell backup-kjøring i backup-entrypoint.sh.
+
+load 'helpers/common'
+
+setup() {
+    setup_stubs
+    BACKUP_DIR="$(mktemp -d)"
+    BACKUP_SUCCESS_FILE="$(mktemp -u)"
+    BACKUP_LOCK_FILE="$(mktemp -u)"
+    export BACKUP_DIR BACKUP_SUCCESS_FILE BACKUP_LOCK_FILE
+
+    export PROJECT_NAME=testprosjekt
+    export DB_PASSWORD=hemmelig
+    export BACKUP_ENCRYPTION_KEY=testnokkel123
+    unset HETZNER_HOST HETZNER_USER FILES_DIR
+    unset STUB_GPG_FAIL STUB_PGDUMP_FAIL STUB_PGISREADY_FAIL
+}
+
+teardown() {
+    rm -rf "$BACKUP_DIR"
+    rm -f "$BACKUP_SUCCESS_FILE"
+    rm -f "$BACKUP_LOCK_FILE"
+    rm -f "${TMPDIR:-/tmp}/stub_gpg_encrypt_count_${BACKUP_DIR//\//_}"
+}
+
+@test "backup hopper over og logger ADVARSEL naar en annen backup holder laas" {
+    # Hold låsen manuelt — simulerer parallell kjøring
+    exec {FD}>"$BACKUP_LOCK_FILE"
+    flock -x "$FD"
+
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"kjores allerede"* ]] || [[ "$output" == *"kjøres allerede"* ]]
+
+    # Ingen backup-fil skal opprettes når backup hoppes over
+    local files
+    files=$(find "$BACKUP_DIR" -maxdepth 1 -name "testprosjekt_*.sql.gz.gpg" 2>/dev/null | wc -l)
+    [ "$files" -eq 0 ]
+
+    flock -u "$FD"
+    exec {FD}>&-
+}
+
+@test "backup kjorer normalt naar ingen annen backup holder laas" {
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -eq 0 ]
+
+    local files
+    files=$(find "$BACKUP_DIR" -maxdepth 1 -name "testprosjekt_*.sql.gz.gpg" | wc -l)
+    [ "$files" -eq 1 ]
+}


### PR DESCRIPTION
Fixes #109

Adds an exclusive `flock` lock in `main()` to prevent concurrent backup runs (e.g. cron + manual). If a lock is already held, the process logs a warning and exits with 0.

- `BACKUP_LOCK_FILE` exposed as overridable env var (defaults to `/tmp/safekeeper-${PROJECT_NAME}.lock`)
- `flock` available via BusyBox in alpine — no Dockerfile changes needed
- Lock released automatically by OS on process exit (crash-safe)
- New `tests/locking.bats` with 2 tests