### PR TITLE
Fix #107: validate backup file size after pg_dump

### DIFF
--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -26,6 +26,7 @@ BACKUP_ENCRYPTION_KEY="${BACKUP_ENCRYPTION_KEY:-}"
 DB_WAIT_TIMEOUT="${DB_WAIT_TIMEOUT:-60}"
 BACKUP_RETRY_MAX="${BACKUP_RETRY_MAX:-3}"
 BACKUP_RETRY_DELAY="${BACKUP_RETRY_DELAY:-5}"
+MIN_BACKUP_SIZE_BYTES="${MIN_BACKUP_SIZE_BYTES:-1024}"
 
 # Interne fil-stier (kan overstyres i tester via env-variabler)
 SAFEKEEPER_ENV_FILE="${SAFEKEEPER_ENV_FILE:-/etc/safekeeper.env}"
@@ -84,6 +85,8 @@ check_requirements() {
         || error "BACKUP_RETRY_MAX må være et positivt heltall >= 1, fikk: '$BACKUP_RETRY_MAX'"
     [[ "$BACKUP_RETRY_DELAY" =~ ^[0-9]+$ ]] && [[ "$BACKUP_RETRY_DELAY" -ge 1 ]] \
         || error "BACKUP_RETRY_DELAY må være et positivt heltall >= 1, fikk: '$BACKUP_RETRY_DELAY'"
+    [[ "$MIN_BACKUP_SIZE_BYTES" =~ ^[0-9]+$ ]] && [[ "$MIN_BACKUP_SIZE_BYTES" -ge 1 ]] \
+        || error "MIN_BACKUP_SIZE_BYTES må være et positivt heltall >= 1, fikk: '$MIN_BACKUP_SIZE_BYTES'"
 
     if [[ -n "$HETZNER_HOST" ]]; then
         [[ "$HETZNER_HOST" =~ ^[a-zA-Z0-9.-]+$ ]] || error "HETZNER_HOST inneholder ugyldige tegn: '$HETZNER_HOST'"
@@ -258,6 +261,15 @@ run_backup() {
             --passphrase-fd 3 3< <(printf '%s' "$BACKUP_ENCRYPTION_KEY") \
         > "$backup_file"
     chmod 600 "$backup_file"
+
+    # Verifiser at backup-filen ikke er mistenkelig liten — tom output fra pg_dump
+    # gir en gyldig (men verdilos) gzip-innpakket fil som passerer gunzip -t
+    local actual_bytes
+    actual_bytes=$(wc -c < "$backup_file")
+    if [[ "$actual_bytes" -lt "$MIN_BACKUP_SIZE_BYTES" ]]; then
+        rm -f "$backup_file"
+        error "Backup-fil er mistenkelig liten (${actual_bytes} bytes < ${MIN_BACKUP_SIZE_BYTES} bytes) — pg_dump kan ha feilet"
+    fi
 
     # Verifiser at backup er gyldig (dekrypterings-test)
     if ! gpg --batch --yes --decrypt \

--- a/tests/encryption.bats
+++ b/tests/encryption.bats
@@ -42,6 +42,9 @@ setup_stubs_without_gpg() {
     cp "${SAFEKEEPER_ROOT}/tests/stubs/"* "$REAL_GPG_STUBS/"
     rm -f "$REAL_GPG_STUBS/gpg"
     export PATH="${REAL_GPG_STUBS}:${PATH}"
+    # Stub pg_dump-output komprimert+kryptert er < 1024 bytes (prod-default).
+    # Sett terskelen til 50 for tester (tom pg_dump gir ~20 bytes < 50).
+    export MIN_BACKUP_SIZE_BYTES="${MIN_BACKUP_SIZE_BYTES:-50}"
 }
 
 @test "round-trip: ekte GPG --symmetric AES256 dekrypterer til identisk klartekst" {

--- a/tests/helpers/common.bash
+++ b/tests/helpers/common.bash
@@ -10,4 +10,7 @@ export SAFEKEEPER_ROOT
 # Kalles fra setup() i .bats-filer som trenger stubs.
 setup_stubs() {
     export PATH="${SAFEKEEPER_ROOT}/tests/stubs:${PATH}"
+    # Stub pg_dump skriver bare ~88 bytes komprimert — langt under prod-default 1024.
+    # Sett terskelen til 50 for tester (STUB_PGDUMP_EMPTY=1 gir ~20 bytes, som er < 50).
+    export MIN_BACKUP_SIZE_BYTES="${MIN_BACKUP_SIZE_BYTES:-50}"
 }

--- a/tests/run_backup.bats
+++ b/tests/run_backup.bats
@@ -113,6 +113,18 @@ load_backup_lib() {
     [[ "$output" == *"forsok"* ]]
 }
 
+@test "run_backup feiler med feilmelding naar pg_dump produserer tom output (STUB_PGDUMP_EMPTY=1)" {
+    export STUB_PGDUMP_EMPTY=1
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"liten"* ]]
+    # Ingen backup-fil eller checksum skal vaere igjen
+    local files
+    files=$(find "$BACKUP_DIR" -maxdepth 1 -name "testprosjekt_*.sql.gz.gpg" | wc -l)
+    [ "$files" -eq 0 ]
+    [ ! -f "$BACKUP_SUCCESS_FILE" ]
+}
+
 @test "run_backup lykkes med SSH-fallback og logger ADVARSEL naar SFTP feiler men SSH virker (lokal backup ok)" {
     # SFTP-subsystem utilgjengelig (STUB_SFTP_FAIL=1), men SSH shell-kommandoer virker.
     # SSH mkdir fallback oppretter katalog; SFTP-verifisering feiler; SSH sha256sum er tom.

--- a/tests/stubs/pg_dump
+++ b/tests/stubs/pg_dump
@@ -2,6 +2,8 @@
 # Stub for pg_dump. Ignorer alle argumenter (inkl. PGPASSFILE).
 # Skriver gyldig SQL-tekst til stdout slik at gzip downstream kan komprimere.
 # Returnerer 1 hvis STUB_PGDUMP_FAIL=1.
+# Skriver ingen output (0 bytes) hvis STUB_PGDUMP_EMPTY=1.
 [[ "${STUB_PGDUMP_FAIL:-0}" == "1" ]] && exit 1
+[[ "${STUB_PGDUMP_EMPTY:-0}" == "1" ]] && exit 0
 printf -- '-- stub pg_dump dump\nCREATE TABLE test (id INT);\nINSERT INTO test VALUES (1);\n'
 exit 0


### PR DESCRIPTION
Fixes #107

Adds a post-write size check in `run_backup()` that catches the silent-failure scenario where `pg_dump` produces no or near-zero output. A valid PG dump is always larger than 1 KB; a near-empty encrypted file would pass `gunzip -t` and silently upload a useless backup to Hetzner.

**Changes:**
- `backup-entrypoint.sh`: Add `MIN_BACKUP_SIZE_BYTES` env var (default 1024), validation in `check_requirements()`, and size check with cleanup after backup file is written
- `tests/stubs/pg_dump`: Add `STUB_PGDUMP_EMPTY=1` support (writes 0 bytes)
- `tests/run_backup.bats`: New test verifying backup fails with clear error on empty pg_dump output
- `tests/helpers/common.bash` + `tests/encryption.bats`: Set `MIN_BACKUP_SIZE_BYTES=50` in test helpers (stub output ~88 bytes > 50 > ~20 bytes for empty gzip)