### PR TITLE
feat #108: proaktiv ntfy-varsling ved backup-feil

### DIFF
--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -42,6 +42,9 @@ HETZNER_USER="${HETZNER_USER:-}"
 HETZNER_PORT="${HETZNER_PORT:-23}"
 HETZNER_BACKUP_PATH="${HETZNER_BACKUP_PATH:-backups/${PROJECT_NAME}}"
 
+# ntfy-varsling (tom = deaktivert)
+NTFY_URL="${NTFY_URL:-}"
+
 # SSH-nokkel via mktemp (ryddes opp via trap)
 SSH_KEY=$(mktemp)
 # sftp bruker -P (stor bokstav) for port, -q for stille modus
@@ -50,7 +53,19 @@ SFTP_OPTS=(-q -i "${SSH_KEY}" -o StrictHostKeyChecking=accept-new -o BatchMode=y
 SSH_OPTS=(-i "${SSH_KEY}" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -p "${HETZNER_PORT}")
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"; }
-error() { log "ERROR: $1" >&2; exit 1; }
+
+notify_ntfy() {
+    [[ -z "${NTFY_URL:-}" ]] && return 0
+    local message="$1"
+    wget -q -O /dev/null \
+        --post-data "BACKUP FEILET (${PROJECT_NAME:-ukjent}): ${message}" \
+        --header "Title: Backup feilet: ${PROJECT_NAME:-ukjent}" \
+        --header "Priority: urgent" \
+        --header "Tags: rotating_light" \
+        "${NTFY_URL}" 2>/dev/null || true
+}
+
+error() { log "ERROR: $1" >&2; notify_ntfy "$1"; exit 1; }
 
 # .pgpass for sikker passordoverlevering (unngaar PGPASSWORD i prosessliste)
 setup_pgpass() {
@@ -388,7 +403,7 @@ main() {
 
     log "Setter opp daglig backup: $BACKUP_SCHEDULE"
     # Eksporter miljovariabler til fil for cron (BusyBox crond arver ikke Docker env)
-    env | grep -E '^(PROJECT_NAME|DB_|BACKUP_|FILES_DIR|HETZNER_|TZ)[^=]*=' | sed "s/^\\([^=]*\\)=\\(.*\\)\$/export \\1='\\2'/" > "$SAFEKEEPER_ENV_FILE"
+    env | grep -E '^(PROJECT_NAME|DB_|BACKUP_|FILES_DIR|HETZNER_|NTFY_|TZ)[^=]*=' | sed "s/^\\([^=]*\\)=\\(.*\\)\$/export \\1='\\2'/" > "$SAFEKEEPER_ENV_FILE"
     chmod 600 "$SAFEKEEPER_ENV_FILE"
     echo "$BACKUP_SCHEDULE . $SAFEKEEPER_ENV_FILE; /usr/local/bin/backup-entrypoint.sh backup >> /var/log/backup.log 2>&1" > "$CRONTAB_FILE"
 

--- a/tests/ntfy.bats
+++ b/tests/ntfy.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+#
+# Tester for proaktiv ntfy-varsling ved backup-feil i backup-entrypoint.sh.
+# Verifiserer at wget kalles med korrekt URL naar NTFY_URL er satt,
+# og at ingen varsling sendes naar NTFY_URL er tom.
+
+load 'helpers/common'
+
+setup() {
+    setup_stubs
+    BACKUP_DIR="$(mktemp -d)"
+    BACKUP_SUCCESS_FILE="$(mktemp -u)"
+    WGET_CALL_LOG="$(mktemp)"
+    export BACKUP_DIR BACKUP_SUCCESS_FILE WGET_CALL_LOG
+
+    export PROJECT_NAME=testprosjekt
+    export DB_PASSWORD=hemmelig
+    export BACKUP_ENCRYPTION_KEY=testnokkel123
+    unset HETZNER_HOST HETZNER_USER FILES_DIR
+    unset STUB_WGET_FAIL
+}
+
+teardown() {
+    rm -rf "$BACKUP_DIR"
+    rm -f "$BACKUP_SUCCESS_FILE"
+    rm -f "$WGET_CALL_LOG"
+}
+
+@test "backup-feil med NTFY_URL satt sender wget-kall til ntfy-URL" {
+    export NTFY_URL="http://ntfy.test/safekeeper"
+    export STUB_PGISREADY_FAIL=always
+    export DB_WAIT_TIMEOUT=4
+
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -ne 0 ]
+
+    [ -s "$WGET_CALL_LOG" ]
+    [[ "$(cat "$WGET_CALL_LOG")" == *"http://ntfy.test/safekeeper"* ]]
+}
+
+@test "backup-feil uten NTFY_URL sender ingen wget-varsling" {
+    unset NTFY_URL
+    export STUB_PGISREADY_FAIL=always
+    export DB_WAIT_TIMEOUT=4
+
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -ne 0 ]
+
+    [ ! -s "$WGET_CALL_LOG" ]
+}
+
+@test "backup-feil med NTFY_URL tom streng sender ingen wget-varsling" {
+    export NTFY_URL=""
+    export STUB_PGISREADY_FAIL=always
+    export DB_WAIT_TIMEOUT=4
+
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -ne 0 ]
+
+    [ ! -s "$WGET_CALL_LOG" ]
+}
+
+@test "ntfy-varsling inkluderer PROJECT_NAME i Title-header" {
+    export NTFY_URL="http://ntfy.test/safekeeper"
+    export STUB_PGISREADY_FAIL=always
+    export DB_WAIT_TIMEOUT=4
+
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -ne 0 ]
+
+    [[ "$(cat "$WGET_CALL_LOG")" == *"testprosjekt"* ]]
+}
+
+@test "ntfy-varsling feiler stille — backup-feil-exit er fortsatt 1 (STUB_WGET_FAIL=1)" {
+    export NTFY_URL="http://ntfy.test/safekeeper"
+    export STUB_WGET_FAIL=1
+    export STUB_PGISREADY_FAIL=always
+    export DB_WAIT_TIMEOUT=4
+
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -ne 0 ]
+}

--- a/tests/stubs/wget
+++ b/tests/stubs/wget
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Stub for wget. Logger alle kall til WGET_CALL_LOG (om satt).
+# Returnerer 1 hvis STUB_WGET_FAIL=1.
+
+if [[ -n "${WGET_CALL_LOG:-}" ]]; then
+    echo "$@" >> "$WGET_CALL_LOG"
+fi
+
+[[ "${STUB_WGET_FAIL:-0}" == "1" ]] && exit 1
+exit 0


### PR DESCRIPTION
Fixes #108

Legger til proaktiv ntfy-push når `error()` kalles i backup-entrypoint.sh.

## Endringer
- Ny `NTFY_URL`-miljøvariabel (tom = deaktivert)
- Ny `notify_ntfy()`-funksjon bruker BusyBox `wget` — ingen nye Dockerfile-avhengigheter
- `error()` kaller `notify_ntfy()` før exit
- Cron-env-eksport inkluderer `NTFY_`-prefiks slik at cron-jobber også varsler
- 5 nye BATS-tester + wget-stub