### PR TITLE
Fix #110: require HETZNER_USER when HETZNER_HOST is set

### DIFF
--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -105,9 +105,8 @@ check_requirements() {
 
     if [[ -n "$HETZNER_HOST" ]]; then
         [[ "$HETZNER_HOST" =~ ^[a-zA-Z0-9.-]+$ ]] || error "HETZNER_HOST inneholder ugyldige tegn: '$HETZNER_HOST'"
-        if [[ -n "$HETZNER_USER" ]]; then
-            [[ "$HETZNER_USER" =~ ^[a-zA-Z0-9_-]+$ ]] || error "HETZNER_USER inneholder ugyldige tegn: '$HETZNER_USER'"
-        fi
+        [[ -n "$HETZNER_USER" ]] || error "HETZNER_USER er påkrevd når HETZNER_HOST er satt"
+        [[ "$HETZNER_USER" =~ ^[a-zA-Z0-9_-]+$ ]] || error "HETZNER_USER inneholder ugyldige tegn: '$HETZNER_USER'"
         [[ "$HETZNER_PORT" =~ ^[0-9]+$ ]] && [[ "$HETZNER_PORT" -ge 1 ]] && [[ "$HETZNER_PORT" -le 65535 ]] \
             || error "HETZNER_PORT er ugyldig: '$HETZNER_PORT'"
         [[ "$HETZNER_BACKUP_PATH" =~ ^[a-zA-Z0-9._/-]+$ ]] || error "HETZNER_BACKUP_PATH inneholder ugyldige tegn: '$HETZNER_BACKUP_PATH'"

--- a/tests/check_requirements.bats
+++ b/tests/check_requirements.bats
@@ -165,6 +165,28 @@ teardown() {
     [[ "$output" == *"HETZNER_PORT"* ]]
 }
 
+@test "backup feiler hvis HETZNER_HOST er satt men HETZNER_USER mangler" {
+    export PROJECT_NAME=testprosjekt
+    export DB_PASSWORD=hemmelig
+    export BACKUP_ENCRYPTION_KEY=nokkel
+    export HETZNER_HOST=hetzner.example.com
+    unset HETZNER_USER
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"HETZNER_USER"* ]]
+}
+
+@test "backup feiler hvis HETZNER_HOST er satt men HETZNER_USER er tom streng" {
+    export PROJECT_NAME=testprosjekt
+    export DB_PASSWORD=hemmelig
+    export BACKUP_ENCRYPTION_KEY=nokkel
+    export HETZNER_HOST=hetzner.example.com
+    export HETZNER_USER=""
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"HETZNER_USER"* ]]
+}
+
 @test "BACKUP_HEALTHCHECK_WINDOW ignoreres av entrypoint (eies av consumer docker-compose)" {
     export PROJECT_NAME=testprosjekt
     export DB_PASSWORD=hemmelig


### PR DESCRIPTION
Fixes #110

Legg til eksplisitt krav om `HETZNER_USER` i `check_requirements()` når `HETZNER_HOST` er konfigurert. Uten denne sjekken kunne operatøren tro at offsite backup var aktiv selv om `HETZNER_USER` manglet — opplasting ble stille hoppet over av `hetzner_configured()`.

**Endringer**:
- `backup-entrypoint.sh`: Erstatter betinget format-validering med krav om at `HETZNER_USER` MÅ være satt + format-sjekk ubetinget
- `tests/check_requirements.bats`: To nye tester (manglende og tom `HETZNER_USER` med `HETZNER_HOST` satt)