### PR TITLE
Test #111: styrk pg_dump drift-vakt til å sammenligne mot Dockerfile

### DIFF
--- a/tests/check_requirements.bats
+++ b/tests/check_requirements.bats
@@ -197,8 +197,11 @@ teardown() {
     [[ "$output" != *"BACKUP_HEALTHCHECK_WINDOW"* ]]
 }
 
-@test "pg_dump --version returnerer PG16 major-versjon (versjonsdrift-vakt)" {
+@test "pg_dump stub-versjon er synkronisert med Dockerfile baseimage (versjonsdrift-vakt)" {
+    dockerfile_major=$(grep '^FROM postgres:' "$SAFEKEEPER_ROOT/Dockerfile" \
+        | sed 's/FROM postgres:\([0-9]*\)\..*/\1/')
+    [ -n "$dockerfile_major" ]
     run pg_dump --version
     [ "$status" -eq 0 ]
-    [[ "$output" =~ [[:space:]]16\. ]]
+    [[ "$output" =~ [[:space:]]${dockerfile_major}[.] ]]
 }


### PR DESCRIPTION
Refs #111.

QA-review (PR #118) avdekket at den forrige testen sammenlignet stubben mot seg selv i stedet for mot Dockerfile. Denne PR fikser det.

**Hva ble gjort:**
- Testen ekstraherer nå major-versjon fra Dockerfile FROM-linje med grep/sed
- Sammenligner pg_dump stub-output mot Dockerfile-versjon — testen feiler faktisk når Dockerfile bumpes uten at stubben oppdateres
- Regex endret fra `\.` til `[.]` for eksplisitt literal-punktum-match

**Drift-vakt-logikken er nå reell:** Dockerfile bump PG16→PG17 uten stub-oppdatering → test 26 rød.