### PR TITLE
Fix #115: make Hetzner mkdir best-effort, remove SSH mkdir fallback

### DIFF
--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -49,7 +49,7 @@ NTFY_URL="${NTFY_URL:-}"
 SSH_KEY=$(mktemp)
 # sftp bruker -P (stor bokstav) for port, -q for stille modus
 SFTP_OPTS=(-q -i "${SSH_KEY}" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -P "${HETZNER_PORT}")
-# SSH_OPTS er fallback naar SFTP-subsystem er utilgjengelig (ssh bruker -p i stedet for -P)
+# SSH_OPTS brukes for sha256sum-verifisering som fallback naar SFTP ls -la er utilgjengelig (ssh bruker -p i stedet for -P)
 SSH_OPTS=(-i "${SSH_KEY}" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -p "${HETZNER_PORT}")
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"; }
@@ -136,9 +136,10 @@ upload_to_hetzner() {
 
     log "Laster opp til Hetzner StorageBox ($HETZNER_HOST)..."
 
-    # Opprett mapper hvis de ikke finnes (ett nivå om gangen — Hetzner støtter ikke mkdir -p).
-    # Prøver SFTP batch først (for SFTP-only StorageBox); faller tilbake til SSH shell-kommandoer
-    # for StorageBox-kontoer der SFTP-subsystemet er utilgjengelig (f.eks. u571604).
+    # Opprett mapper hvis de ikke finnes (best-effort — ett nivå om gangen, Hetzner støtter ikke mkdir -p).
+    # SSH-fallback brukes ikke: StorageBox restricted shell avviser SSH-kommandoer ("Command not found").
+    # Feiler sftp mkdir+ls (f.eks. katalog finnes allerede, eller kontospesifikk SFTP-konfig),
+    # logges det som advarsel og opplastingen fortsetter — sftp put avgjør om katalogen eksisterer.
     local path_parts
     IFS='/' read -ra path_parts <<< "${HETZNER_BACKUP_PATH}"
     local current_path=""
@@ -147,11 +148,7 @@ upload_to_hetzner() {
         current_path="${current_path:+${current_path}/}${part}"
         if ! printf -- '-mkdir %s\nls %s\n' "${current_path}" "${current_path}" \
                 | sftp "${SFTP_OPTS[@]}" "${HETZNER_USER}@${HETZNER_HOST}" >/dev/null 2>&1; then
-            # SFTP-subsystem utilgjengelig — fall tilbake til SSH shell-kommandoer
-            # shellcheck disable=SC2029
-            ssh "${SSH_OPTS[@]}" "${HETZNER_USER}@${HETZNER_HOST}" mkdir "${current_path}" 2>/dev/null \
-                || ssh "${SSH_OPTS[@]}" "${HETZNER_USER}@${HETZNER_HOST}" test -d "${current_path}" \
-                || { log "ADVARSEL: Kan ikke opprette eller bekrefte katalog '${current_path}' på Hetzner (SFTP og SSH feilet)"; return 1; }
+            log "ADVARSEL: SFTP mkdir '${current_path}' feilet — katalog finnes muligens allerede, fortsetter opplasting"
         fi
     done
 

--- a/tests/hetzner_retry.bats
+++ b/tests/hetzner_retry.bats
@@ -90,8 +90,8 @@ load_backup_lib() {
     [[ "$output" == *"Kunne ikke bekrefte"* ]]
 }
 
-@test "upload_to_hetzner returnerer 1 og logger katalog-feil naar baade SFTP og SSH feiler" {
-    # Bade SFTP og SSH maa feile for at katalog-oppretting skal returnere 1
+@test "upload_to_hetzner returnerer 1 naar full SFTP-feil (mkdir advarsel + put feiler)" {
+    # Bade mkdir-batch og put feiler (SFTP nede) — status 1, advarsel med 'katalog' fra mkdir
     export STUB_SFTP_FAIL=1
     export STUB_SSH_FAIL=1
     load_backup_lib
@@ -102,6 +102,23 @@ load_backup_lib() {
     run upload_to_hetzner "$dummy"
     [ "$status" -eq 1 ]
     [[ "$output" == *"katalog"* ]]
+}
+
+@test "upload_to_hetzner lykkes naar SFTP mkdir-batch feiler men put lykkes (u571604-scenario)" {
+    # StorageBox u571604: mkdir+ls-batch feiler (sftp exit 1 ved 'ls path'),
+    # SSH er utilgjengelig (restricted shell). Gammel kode returnerte 1 pga
+    # hard-gating paa mkdir. Ny kode: mkdir best-effort, put kjores uansett.
+    export STUB_SFTP_LS_FAIL=1
+    export STUB_SSH_FAIL=1
+    export STUB_SFTP_LS_SIZE=7
+    load_backup_lib
+
+    local dummy="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
+    printf 'content' > "$dummy"
+
+    run upload_to_hetzner "$dummy"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"lastet opp og verifisert"* ]]
 }
 
 @test "upload_with_retry respekterer BACKUP_RETRY_MAX=1 (ingen gjenforsok)" {
@@ -129,19 +146,6 @@ load_backup_lib() {
     [[ "$output" == *"forsok 1/2"* ]]
     [[ "$output" == *"feilet etter 2 forsok"* ]]
     [[ "$output" != *"forsok 2/2"* ]]
-}
-
-@test "upload_to_hetzner returnerer 1 og logger katalog-feil naar baade SFTP og SSH feiler (2)" {
-    export STUB_SFTP_FAIL=1
-    export STUB_SSH_FAIL=1
-    load_backup_lib
-
-    local dummy="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
-    echo "content" > "$dummy"
-
-    run upload_to_hetzner "$dummy"
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"katalog"* ]]
 }
 
 @test "upload_to_hetzner feiler naar SFTP-subsystem er utilgjengelig (ingen SSH-fallback for opplasting)" {

--- a/tests/stubs/sftp
+++ b/tests/stubs/sftp
@@ -8,6 +8,7 @@
 #   STUB_SFTP_LS_OUTPUT       - rå ls-la-formatert output for ls-la-kommandoer
 #   STUB_SFTP_LS_SIZE         - filstørrelse som returneres for ls-la-enkeltfil (default: 7)
 #   STUB_SFTP_LS_EMPTY=1      - ls -la returnerer ingen output (verifisering feiler)
+#   STUB_SFTP_LS_FAIL=1       - plain ls (uten -la) feiler (exit 1) — simulerer u571604-scenario
 #   STUB_SFTP_WRONG_SIZE=1    - returnerer feil størrelse (for å simulere størrelsesmismatch)
 #   STUB_SFTP_RM_FAIL=1       - rm-kommandoer feiler (exit 1)
 #   STUB_SFTP_PUT_FAIL=1      - put-kommandoer feiler (exit 1)
@@ -54,6 +55,9 @@ while IFS= read -r cmd; do
                     echo "-rw-r--r--    1 u12345  u12345       ${size} Jun  1 03:00 ${filename}"
                 fi
             elif [[ "$bare_cmd" == "ls "* ]]; then
+                if [[ "${STUB_SFTP_LS_FAIL:-0}" == "1" ]]; then
+                    exit 1
+                fi
                 [[ -n "${STUB_SFTP_LS_OUTPUT:-}" ]] && echo "${STUB_SFTP_LS_OUTPUT}"
             fi
             ;;


### PR DESCRIPTION
Fixes #115

## Rotårsak
`upload_to_hetzner()` hard-gatet katalogoppretting — `return 1` avbrøt FØR `sftp put` kjørte. SSH mkdir-fallback (commit `4953171`) er fundamentalt inkompatibel med StorageBox restricted shell: avviser alle SSH-kommandoer med «Command not found».

## Endringer
- **`backup-entrypoint.sh`**: SFTP mkdir er nå best-effort — logger `ADVARSEL` ved feil men avbryter ikke. SSH mkdir-fallback fjernet.
- **`tests/hetzner_retry.bats`**: Ny test for u571604-scenariet (sftp mkdir feiler, put lykkes → status 0). Duplikattest fjernet. Eksisterende test oppdatert med ny beskrivelse.
- **`tests/stubs/sftp`**: Ny stub-variabel `STUB_SFTP_LS_FAIL=1` for å simulere mkdir+ls-batch som feiler.

## TDD
- Rød test: `upload_to_hetzner lykkes naar SFTP mkdir-batch feiler men put lykkes (u571604-scenario)` — feilet med gammel kode
- 94/94 tester grønne etter fix