### PR TITLE
chore: bump baseimage til postgres:17.10-alpine (#119)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Docker Compose (per app)
             +-- cleanup (retention lokalt + Hetzner)
 ```
 
-**Baseimage:** `postgres:16.14-alpine@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229` (gir tilgang til `pg_dump`, `pg_isready`, `psql`)
+**Baseimage:** `postgres:17.10-alpine@sha256:979c4379dd698aba0b890599a6104e082035f98ef31d9b9291ec22f2b13059ca` (gir tilgang til `pg_dump`, `pg_isready`, `psql`)
 
 **Ekstra pakker:** bash, gzip, gnupg, openssh-client, tzdata
 
@@ -39,7 +39,7 @@ Docker Compose (per app)
 |-----|-------------|
 | `backup-entrypoint.sh` | Hovedskript - backup, kryptering, opplasting, opprydding, cron |
 | `restore.sh` | Gjenoppretting fra lokal backup-fil |
-| `Dockerfile` | Docker-image basert pa postgres:16.14-alpine (pinnet til digest) |
+| `Dockerfile` | Docker-image basert pa postgres:17.10-alpine (pinnet til digest) |
 
 ### Backup-flyt
 
@@ -130,7 +130,7 @@ Sensitive filer ryddes opp via `trap EXIT`:
 - `StrictHostKeyChecking=accept-new` (TOFU-modell - aksepterer nye nokler, avviser endrede)
 - `BatchMode=yes` (ingen interaktive prompts)
 - Port 23 (Hetzner StorageBox standard)
-- **Dato-ekstraksjon**: `cleanup_hetzner` bruker POSIX sed (ikke `grep -oP`), siden BusyBox grep i postgres:16.14-alpine ikke støtter Perl-regex
+- **Dato-ekstraksjon**: `cleanup_hetzner` bruker POSIX sed (ikke `grep -oP`), siden BusyBox grep i postgres:17.10-alpine ikke støtter Perl-regex
 - **Merk**: SSH brukes IKKE for directory-creation — StorageBox restricted shell avviser shell-kommandoer med "Command not found"
 
 ### Filpermisjon

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:16.14-alpine@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229
+FROM postgres:17.10-alpine@sha256:979c4379dd698aba0b890599a6104e082035f98ef31d9b9291ec22f2b13059ca
 
 RUN apk add --no-cache \
     bash \

--- a/tests/hetzner_cleanup.bats
+++ b/tests/hetzner_cleanup.bats
@@ -142,7 +142,7 @@ sftp_process_count() {
 }
 
 @test "cleanup_hetzner sletter gammel fil — dato-ekstraksjon med POSIX sed (BusyBox-kompatibel)" {
-    # grep -oP (Perl-regex) støttes ikke i BusyBox grep (postgres:16-alpine).
+    # grep -oP (Perl-regex) støttes ikke i BusyBox grep (postgres:17-alpine).
     # Verifiserer at dato-ekstraksjon fungerer og at filen inkluderes i rm-kommandoen.
     export STUB_SFTP_LS_OUTPUT="$(ls_la_line "testprosjekt_20200101_030000.sql.gz.gpg")"
 

--- a/tests/stubs/pg_dump
+++ b/tests/stubs/pg_dump
@@ -4,7 +4,7 @@
 # Returnerer 1 hvis STUB_PGDUMP_FAIL=1.
 # Skriver ingen output (0 bytes) hvis STUB_PGDUMP_EMPTY=1.
 # Versjon holdes synkronisert med baseimage i Dockerfile (drift-vakt: check_requirements.bats).
-[[ "${1:-}" == "--version" ]] && echo "pg_dump (PostgreSQL) 16.14" && exit 0
+[[ "${1:-}" == "--version" ]] && echo "pg_dump (PostgreSQL) 17.10" && exit 0
 [[ "${STUB_PGDUMP_FAIL:-0}" == "1" ]] && exit 1
 [[ "${STUB_PGDUMP_EMPTY:-0}" == "1" ]] && exit 0
 printf -- '-- stub pg_dump dump\nCREATE TABLE test (id INT);\nINSERT INTO test VALUES (1);\n'


### PR DESCRIPTION
Fixes #119 (del av #111).

## Endringer
- `Dockerfile`: `FROM postgres:16.14-alpine@sha256:16bc17c…` → `postgres:17.10-alpine@sha256:979c4379…` (digest verifisert med `docker pull` + `docker manifest inspect`)
- `tests/stubs/pg_dump`: `--version` → `pg_dump (PostgreSQL) 17.10`
- `CLAUDE.md`: tre baseimage-referanser oppdatert til 17.10
- `tests/hetzner_cleanup.bats`: stale `postgres:16`-kommentar → `17`

## Versjonsdrift-vakt
`check_requirements.bats` test 26 leser major **dynamisk** fra Dockerfile-FROM-linjen og matcher mot stubens `pg_dump --version`. Den trengte derfor ingen redigering utover stub-bumpen — verifisert grønn lokalt (`bats tests/check_requirements.bats -f versjonsdrift` → ok 1).

## Kompatibilitet
pg_dump 17 støtter dump mot PG16-server, så denne kan landes uavhengig av consumer-DB-migrasjoner (forward-dump-stien er trygg). Avblokkerer #120.

## AC
- [x] Dockerfile FROM pinnet til `postgres:17.10-alpine@sha256:…`
- [x] pg_dump-stub `--version` = 17.10
- [x] versjonsdrift-vakt grønn (dynamisk — forventer nå 17)
- [x] CLAUDE.md baseimage-referanser oppdatert
- [ ] CI grønn (ShellCheck + Hadolint + BATS + Docker Build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)