### PR TITLE
chore: remove semver-major ignore for docker in dependabot.yml (#120)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,9 +15,6 @@ updates:
       - "docker"
     commit-message:
       prefix: "deps(docker)"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,8 @@ Docker Compose (per app)
 
 **Baseimage:** `postgres:17.10-alpine@sha256:979c4379dd698aba0b890599a6104e082035f98ef31d9b9291ec22f2b13059ca` (gir tilgang til `pg_dump`, `pg_isready`, `psql`)
 
+**Dependabot-policy for major-versjoner:** Ignoren for `version-update:semver-major` på docker er fjernet (fra #120). Dependabot foreslår automatisk PR-er ved PG18, PG19 osv. Disse auto-merges IKKE stille — drift-vakten i `tests/check_requirements.bats` gater majors ved å feile CI inntil `tests/stubs/pg_dump` bevisst oppdateres.
+
 **Ekstra pakker:** bash, gzip, gnupg, openssh-client, tzdata
 
 **Tidssone:** `Europe/Oslo`


### PR DESCRIPTION
Fixes #120

Fjerner `ignore: version-update:semver-major` for docker i `.github/dependabot.yml`. Dependabot vil nå automatisk foreslå PR-er for PG18, PG19 osv.

Sikkerhetsnettet: drift-vakten i `tests/check_requirements.bats` feiler CI ved uventet major-versjonsdrift, så ingen major auto-merges stille uten bevisst oppdatering av `tests/stubs/pg_dump`.

Dokumenterer beslutningen i CLAUDE.md (baseimage-seksjonen).