### PR TITLE
fix: cron env export og SFTP full-sti-håndtering

### DIFF
--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -206,15 +206,19 @@ cleanup_hetzner() {
 
     local files_to_delete=()
     while read -r remote_file; do
-        if [[ ! "$remote_file" =~ ^[a-zA-Z0-9._-]+$ ]]; then
-            log "ADVARSEL: Avvist filnavn med ugyldige tegn: $remote_file"
+        # Noen SFTP-servere returnerer fulle stier (f.eks. "backups/hwa/fil.gpg") i ls-output.
+        # Bruk basename for å validere og referere kun filnavnet, uavhengig av format.
+        local filename
+        filename=$(basename "$remote_file")
+        if [[ ! "$filename" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+            log "ADVARSEL: Avvist filnavn med ugyldige tegn: $filename"
             continue
         fi
         local file_date
-        file_date=$(echo "$remote_file" | sed -n "s/.*${PROJECT_NAME}_\([0-9]\{8\}\).*/\1/p" || echo "")
+        file_date=$(echo "$filename" | sed -n "s/.*${PROJECT_NAME}_\([0-9]\{8\}\).*/\1/p" || echo "")
         if [[ -n "$file_date" ]] && [[ "$file_date" < "$cutoff_ts" ]]; then
-            log "Markerer for sletting: $remote_file"
-            files_to_delete+=("${HETZNER_BACKUP_PATH}/${remote_file}")
+            log "Markerer for sletting: $filename"
+            files_to_delete+=("${HETZNER_BACKUP_PATH}/${filename}")
         fi
     done < <(printf 'ls -la %s\n' "${HETZNER_BACKUP_PATH}" \
         | sftp "${SFTP_OPTS[@]}" "${HETZNER_USER}@${HETZNER_HOST}" 2>/dev/null \
@@ -396,8 +400,14 @@ main() {
     date +%s > "$BACKUP_SUCCESS_FILE"
 
     log "Setter opp daglig backup: $BACKUP_SCHEDULE"
-    # Eksporter miljovariabler til fil for cron (BusyBox crond arver ikke Docker env)
-    env | grep -E '^(PROJECT_NAME|DB_|BACKUP_|FILES_DIR|HETZNER_|NTFY_|TZ)[^=]*=' | sed "s/^\\([^=]*\\)=\\(.*\\)\$/export \\1='\\2'/" > "$SAFEKEEPER_ENV_FILE"
+    # Eksporter miljovariabler til fil for cron (BusyBox crond arver ikke Docker env).
+    # printf '%q' håndterer enkle anførselstegn og andre spesialtegn i verdiene korrekt,
+    # i motsetning til sed-basert enkelt-quote-wrapper som brytes ved ' i verdien.
+    while IFS= read -r _sk_line; do
+        _sk_key="${_sk_line%%=*}"
+        _sk_val="${_sk_line#*=}"
+        printf "export %s=%q\n" "$_sk_key" "$_sk_val"
+    done < <(env | grep -E '^(PROJECT_NAME|DB_|BACKUP_|FILES_DIR|HETZNER_|NTFY_|TZ)[^=]*=') > "$SAFEKEEPER_ENV_FILE"
     chmod 600 "$SAFEKEEPER_ENV_FILE"
     echo "$BACKUP_SCHEDULE . $SAFEKEEPER_ENV_FILE; /usr/local/bin/backup-entrypoint.sh backup >> /var/log/backup.log 2>&1" > "$CRONTAB_FILE"
 

--- a/tests/cron.bats
+++ b/tests/cron.bats
@@ -64,3 +64,15 @@ teardown() {
     perms=$(stat -c '%a' "$SAFEKEEPER_ENV_FILE")
     [ "$perms" = "600" ]
 }
+
+@test "safekeeper.env bevarer BACKUP_ENCRYPTION_KEY med enkle anfoerselstegn" {
+    export BACKUP_ENCRYPTION_KEY="nokkel'med'enkle"
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh"
+    [ "$status" -eq 0 ]
+
+    [ -f "$SAFEKEEPER_ENV_FILE" ]
+    # Sourcing av env-filen skal gi korrekt verdi
+    # shellcheck disable=SC1090
+    source "$SAFEKEEPER_ENV_FILE"
+    [ "$BACKUP_ENCRYPTION_KEY" = "nokkel'med'enkle" ]
+}

--- a/tests/hetzner_cleanup.bats
+++ b/tests/hetzner_cleanup.bats
@@ -151,3 +151,21 @@ sftp_process_count() {
 
     grep -q 'testprosjekt_20200101_030000.sql.gz.gpg' "$STUB_SFTP_CALL_LOG"
 }
+
+@test "cleanup_hetzner haandterer fulle stier i SFTP ls-output (Hetzner-format)" {
+    # Noen Hetzner StorageBox-konfigurasjoner returnerer fulle stier i ls-output.
+    # Uten basename-haandtering avvises slike filer med 'ugyldige tegn'-advarsel
+    # og slettes aldri (skraff akkumulerer pa Hetzner).
+    local full_path="backups/testprosjekt/testprosjekt_20200101_030000.sql.gz.gpg"
+    local l1
+    l1="-rw-r--r--    1 u12345  u12345      12345 Jan  1 2020 ${full_path}"
+    export STUB_SFTP_LS_OUTPUT="${l1}"
+
+    load_backup_lib
+    run cleanup_hetzner
+
+    # Skal IKKE logge advarsel om ugyldige tegn for denne filen
+    ! echo "$output" | grep -q "Avvist filnavn"
+    # Filen skal markeres for sletting
+    grep -q 'testprosjekt_20200101_030000.sql.gz.gpg' "$STUB_SFTP_CALL_LOG"
+}


### PR DESCRIPTION
Fixes TommySkogstad/misc-scripts#917

## Problem 1: Cron backup feiler stille ved spesialtegn i env-variabler

Cron-env-filen ble generert med `sed` som wraplet verdier i enkle anførselstegn:
```
export BACKUP_ENCRYPTION_KEY='verdi'
```
Hvis verdien inneholder `'`, produserte sed et ødelagt export-utsagn som ble ignorert ved sourcing — BACKUP_ENCRYPTION_KEY ble tom/feil, og `check_requirements` avsluttet backup-jobben stille.

**Fix**: Erstatter sed med `printf '%q'` som korrekt escaper alle spesialtegn.

## Problem 2: Hetzner cleanup hopper over filer ved full-sti i SFTP ls-output

Noen Hetzner StorageBox-konfigurasjoner returnerer fulle stier i ls-output (`backups/hwa/fil.gpg` i stedet for bare `fil.gpg`). Filnavn-validering brukte regex `^[a-zA-Z0-9._-]+$` som avviste stier pga. `/` — alle gamle Hetzner-filer ble dermed aldri slettet.

**Fix**: `basename` ekstraherer kun filnavnet, uavhengig av om SFTP returnerer fullt sti eller bare filnavn.

## Tester
- Ny test: `BACKUP_ENCRYPTION_KEY` med enkle anførselstegn bevares korrekt i env-filen
- Ny test: `cleanup_hetzner` håndterer fulle stier i SFTP ls-output

96/96 BATS-tester grønne.