### PR TITLE
fix: release lock fd before exec crond to unblock scheduled backups

### DIFF
--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -411,6 +411,9 @@ main() {
     chmod 600 "$SAFEKEEPER_ENV_FILE"
     echo "$BACKUP_SCHEDULE . $SAFEKEEPER_ENV_FILE; /usr/local/bin/backup-entrypoint.sh backup >> /var/log/backup.log 2>&1" > "$CRONTAB_FILE"
 
+    # Frigir flock-låsen før exec crond — ellers arver crond fd-en og blokkerer alle fremtidige cron-kjøringer.
+    exec {LOCK_FD}>&-
+
     log "Starter cron daemon..."
     exec crond -f -l 2
 }

--- a/tests/locking.bats
+++ b/tests/locking.bats
@@ -51,3 +51,43 @@ teardown() {
     files=$(find "$BACKUP_DIR" -maxdepth 1 -name "testprosjekt_*.sql.gz.gpg" | wc -l)
     [ "$files" -eq 1 ]
 }
+
+@test "lock-fd frigis foer exec crond saa cron-jobber ikke blokkeres av arvet flock" {
+    # Regresjonstest for feil der exec crond arvet LOCK_FD og blokkerte alle
+    # fremtidige cron-kjøringer med "En backup kjores allerede".
+    #
+    # Bruker crond-stub som forker en child-prosess og sjekker om den kan ta
+    # lock-filen. Child blokkeres hvis parent (crond) holder arvet fd med flock.
+    local custom_stubs
+    custom_stubs="$(mktemp -d)"
+    cat > "${custom_stubs}/crond" <<'STUB'
+#!/bin/bash
+# Sjekker om child-prosess (simulert cron-jobb) kan ta BACKUP_LOCK_FILE.
+# Blokkeres hvis crond arvet lock-fd med aktiv flock.
+result=$(
+    exec {CHECK_FD}>"${BACKUP_LOCK_FILE}"
+    if flock -xn "$CHECK_FD"; then
+        echo "LOCK_AVAILABLE"
+    else
+        echo "LOCK_HELD_BY_CROND"
+    fi
+)
+echo "$result"
+exit 0
+STUB
+    chmod +x "${custom_stubs}/crond"
+
+    local safekeeper_env_file crontab_file
+    safekeeper_env_file="$(mktemp -u)"
+    crontab_file="$(mktemp -u)"
+    export SAFEKEEPER_ENV_FILE="$safekeeper_env_file"
+    export CRONTAB_FILE="$crontab_file"
+
+    run env PATH="${custom_stubs}:${SAFEKEEPER_ROOT}/tests/stubs:${PATH}" \
+        bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"LOCK_AVAILABLE"* ]]
+
+    rm -rf "$custom_stubs"
+    rm -f "$safekeeper_env_file" "$crontab_file"
+}


### PR DESCRIPTION
## Rotårsak

`backup-entrypoint.sh` åpnet `BACKUP_LOCK_FILE` med en eksklusiv `flock` i det
innledende oppstartsskallet, og kalte deretter `exec crond`. BusyBox crond arvet
den åpne file-descriptoren og holdt `flock`-låsen uendelig lenge.

Hver påfølgende cron-jobb-kjøring (barnprosess av crond) arvede igjen fd-en, så
den eksklusive låsen ble holdt av barnprosessen selv. Når backup-scriptet åpnet
lock-filen på nytt og forsøkte `flock -xn`, ble det blokkert av sin egen
arvede fd → `"En backup kjores allerede"` → avsluttet uten å ta backup.

Symptom: `styreportal-prod-backup-1` og `hwa-prod-backup-1` ble unhealthy
(backup ikke tatt siden 2026-06-05 og 2026-06-04 respektivt).

## Fiks

```bash
exec {LOCK_FD}>&-   # frigir flock-låsen
exec crond -f -l 2
```

## Test

Ny regresjonstest i `locking.bats`:

- Bruker en egendefinert `crond`-stub som forker en child-prosess
- Child forsøker å ta lock-filen med `flock -xn`
- Testen verifiserer at child får `LOCK_AVAILABLE` (ikke `LOCK_HELD_BY_CROND`)
- Fanger regression: uten fiksen blokkeres child av arvet fd

## Påvirket infrastruktur

For å fikse de kjørende containerne (manuell workaround frem til deploy):

```bash
docker exec styreportal-prod-backup-1 rm -f /tmp/safekeeper-styreportal.lock
docker exec hwa-prod-backup-1 rm -f /tmp/safekeeper-hwa.lock
# Kjør manuell backup for å oppdatere BACKUP_SUCCESS_FILE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)