### PR TITLE
Fix: SSH connection timeouts to prevent hung sftp from holding lock

### DIFF
--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -47,10 +47,12 @@ NTFY_URL="${NTFY_URL:-}"
 
 # SSH-nokkel via mktemp (ryddes opp via trap)
 SSH_KEY=$(mktemp)
-# sftp bruker -P (stor bokstav) for port, -q for stille modus
-SFTP_OPTS=(-q -i "${SSH_KEY}" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -P "${HETZNER_PORT}")
+# sftp bruker -P (stor bokstav) for port, -q for stille modus.
+# ConnectTimeout/ServerAlive forhindrer at en hengt sftp-prosess arver LOCK_FD (flock)
+# og blokkerer fremtidige cron-backups i dagevis (rotaarsak for hwa/styreportal-incident 2026-06-07).
+SFTP_OPTS=(-q -i "${SSH_KEY}" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -P "${HETZNER_PORT}" -o ConnectTimeout=30 -o ServerAliveInterval=15 -o ServerAliveCountMax=3)
 # SSH_OPTS brukes for sha256sum-verifisering som fallback naar SFTP ls -la er utilgjengelig (ssh bruker -p i stedet for -P)
-SSH_OPTS=(-i "${SSH_KEY}" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -p "${HETZNER_PORT}")
+SSH_OPTS=(-i "${SSH_KEY}" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -p "${HETZNER_PORT}" -o ConnectTimeout=30 -o ServerAliveInterval=15 -o ServerAliveCountMax=3)
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"; }
 

--- a/tests/hetzner_retry.bats
+++ b/tests/hetzner_retry.bats
@@ -222,3 +222,38 @@ load_backup_lib() {
     [[ "$output" == *"feilet etter 1 forsok"* ]]
     [[ "$output" != *"Prover igjen"* ]]
 }
+
+@test "sftp-kall inkluderer ConnectTimeout og ServerAlive for aa forhindre hengt lock-fd" {
+    # Regresjonstest for incident 2026-06-07 (hwa/styreportal):
+    # En hengt sftp-prosess arvet LOCK_FD og blokkerte cron-backups i 3 dager.
+    # Verifiserer at SFTP_OPTS inneholder timeout-opsjoner slik at sftp aldri
+    # henger uendelig og frigir låsen innen ~75 sekunder.
+    local call_log
+    call_log="$(mktemp)"
+    export STUB_SFTP_CALL_LOG="$call_log"
+    export STUB_SFTP_LS_SIZE=7
+    load_backup_lib
+
+    local dummy="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
+    printf 'content' > "$dummy"
+
+    run upload_to_hetzner "$dummy"
+    [ "$status" -eq 0 ]
+
+    local sftp_args
+    sftp_args=$(cat "$call_log")
+    [[ "$sftp_args" == *"ConnectTimeout=30"* ]] || {
+        echo "FEIL: ConnectTimeout=30 mangler i sftp-kallet: $sftp_args" >&2
+        return 1
+    }
+    [[ "$sftp_args" == *"ServerAliveInterval=15"* ]] || {
+        echo "FEIL: ServerAliveInterval=15 mangler i sftp-kallet: $sftp_args" >&2
+        return 1
+    }
+    [[ "$sftp_args" == *"ServerAliveCountMax=3"* ]] || {
+        echo "FEIL: ServerAliveCountMax=3 mangler i sftp-kallet: $sftp_args" >&2
+        return 1
+    }
+
+    rm -f "$call_log"
+}


### PR DESCRIPTION
## Problem

Backup containers (`hwa-prod-backup-1`, `styreportal-prod-backup-1`) reported
unhealthy on 2026-06-07 after missing 3 consecutive daily backups (Jun 5-7).

**Root cause**: When `backup-entrypoint.sh` runs the initial startup backup,
bash forks a `sftp` subprocess for Hetzner upload. This subprocess inherits
`LOCK_FD` (the flock exclusive lock fd). If the sftp connection hangs (no
timeout configured), the inherited fd keeps the flock lock alive — even after
the parent does `exec {LOCK_FD}>&-`. All subsequent cron-triggered backups
find the lock held and exit with "En backup kjores allerede", leaving
`/tmp/last-backup-success` stale → container becomes unhealthy after 26h.

**Evidence from `/var/log/backup.log`**:
```
[2026-06-05 02:00:01] ADVARSEL: En backup kjores allerede (/tmp/safekeeper-hwa.lock)
[2026-06-06 02:00:00] ADVARSEL: En backup kjores allerede (/tmp/safekeeper-hwa.lock)
[2026-06-07 02:00:00] ADVARSEL: En backup kjores allerede (/tmp/safekeeper-hwa.lock)
```

## Fix

Add SSH connection timeouts to `SFTP_OPTS` and `SSH_OPTS`:
- `ConnectTimeout=30` — give up connecting after 30 seconds
- `ServerAliveInterval=15` — send keepalive every 15 seconds
- `ServerAliveCountMax=3` — give up after 45 seconds of silence

Max hang time: ~75 seconds, after which sftp exits and releases the inherited
lock fd. The next cron run will successfully acquire the lock.

## Test plan

- [x] New regression test: `sftp-kall inkluderer ConnectTimeout og ServerAlive for aa forhindre hengt lock-fd`
- [x] Full test suite: 98/98 tests pass
- [x] Existing locking tests verify core flock behavior is unchanged

Fixes TommySkogstad/misc-scripts#919.

🤖 Generated with [Claude Code](https://claude.com/claude-code)