### PR TITLE
Fix CVE-2026-31789, CVE-2026-33845, CVE-2026-42010, CVE-2026-22184 — apk upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM postgres:17.10-alpine@sha256:979c4379dd698aba0b890599a6104e082035f98ef31d9b9291ec22f2b13059ca
+FROM postgres:17-alpine
 
-RUN apk add --no-cache \
+RUN apk update && apk upgrade --no-cache && apk add --no-cache \
     bash \
     gzip \
     gnupg \

--- a/tests/check_requirements.bats
+++ b/tests/check_requirements.bats
@@ -199,7 +199,7 @@ teardown() {
 
 @test "pg_dump stub-versjon er synkronisert med Dockerfile baseimage (versjonsdrift-vakt)" {
     dockerfile_major=$(grep '^FROM postgres:' "$SAFEKEEPER_ROOT/Dockerfile" \
-        | sed 's/FROM postgres:\([0-9]*\)\..*/\1/')
+        | sed 's/FROM postgres:\([0-9]*\).*/\1/')
     [ -n "$dockerfile_major" ]
     run pg_dump --version
     [ "$status" -eq 0 ]


### PR DESCRIPTION
Fixes TommySkogstad/biologportal#1251

## Endring
- Fjerner pinned postgres:17.10-alpine@sha256:... digest
- Bruker flytende postgres:17-alpine tag
- Legger til 'apk update && apk upgrade' for å hente seneste security patches

## Begrunnelse
Trivy-scan fant CRITICAL CVE-er i os-pakker (libcrypto3, gnutls, zlib). 
Den pinned digest-en låste oss til en stabil release uten oppdateringer.
Flytende tag + apk upgrade sikrer at vi får seneste patches fra Alpine-repoene.

## Verifisering
- Etter merge: biologportal rebuild og Trivy-scan
- Timing: Rebuild utenfor backup-cron (01:50)