### PR TITLE
Fix #142: legg til --clean --if-exists i pg_dump for idempotent restore

### DIFF
--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -271,6 +271,7 @@ run_backup() {
     pg_dump \
         -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" \
         --no-owner --no-privileges --format=plain \
+        --clean --if-exists \
         | gzip \
         | gpg --batch --yes --symmetric --cipher-algo AES256 \
             --passphrase-fd 3 3< <(printf '%s' "$BACKUP_ENCRYPTION_KEY") \

--- a/tests/run_backup.bats
+++ b/tests/run_backup.bats
@@ -125,6 +125,20 @@ load_backup_lib() {
     [ ! -f "$BACKUP_SUCCESS_FILE" ]
 }
 
+@test "run_backup kaller pg_dump med --clean og --if-exists for idempotent restore" {
+    local args_file
+    args_file="$(mktemp)"
+    export STUB_PGDUMP_ARGS_FILE="$args_file"
+
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -eq 0 ]
+
+    grep -qx -- '--clean' "$args_file"
+    grep -qx -- '--if-exists' "$args_file"
+
+    rm -f "$args_file"
+}
+
 @test "run_backup lykkes med SSH-fallback og logger ADVARSEL naar SFTP feiler men SSH virker (lokal backup ok)" {
     # SFTP-subsystem utilgjengelig (STUB_SFTP_FAIL=1), men SSH shell-kommandoer virker.
     # SSH mkdir fallback oppretter katalog; sftp put feiler; ingen scp-fallback.

--- a/tests/stubs/pg_dump
+++ b/tests/stubs/pg_dump
@@ -3,9 +3,11 @@
 # Skriver gyldig SQL-tekst til stdout slik at gzip downstream kan komprimere.
 # Returnerer 1 hvis STUB_PGDUMP_FAIL=1.
 # Skriver ingen output (0 bytes) hvis STUB_PGDUMP_EMPTY=1.
+# Logger alle argumenter til STUB_PGDUMP_ARGS_FILE hvis satt.
 # Versjon holdes synkronisert med baseimage i Dockerfile (drift-vakt: check_requirements.bats).
 [[ "${1:-}" == "--version" ]] && echo "pg_dump (PostgreSQL) 17.10" && exit 0
 [[ "${STUB_PGDUMP_FAIL:-0}" == "1" ]] && exit 1
 [[ "${STUB_PGDUMP_EMPTY:-0}" == "1" ]] && exit 0
+[[ -n "${STUB_PGDUMP_ARGS_FILE:-}" ]] && printf '%s\n' "$@" > "$STUB_PGDUMP_ARGS_FILE"
 printf -- '-- stub pg_dump dump\nCREATE TABLE test (id INT);\nINSERT INTO test VALUES (1);\n'
 exit 0


### PR DESCRIPTION
Fixes #142

Legger til `--clean --if-exists` i `pg_dump`-kallet slik at restore-operasjoner er idempotente mot eksisterende databaser. Uten disse flaggene feiler restore med "relation already exists" hvis måldatabasen ikke er tom.

Ny BATS-test verifiserer at flaggene sendes til pg_dump.