### PR TITLE
Fix #149: add SHA256-digest to postgres:17-alpine baseimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:17-alpine
+FROM postgres:17-alpine@sha256:0a8a1e76503c091f0feb387d51b10fcd746c2d61cf6cdd6e8356973a45e40a0f
 
 RUN apk update && apk upgrade --no-cache && apk add --no-cache \
     bash \

--- a/tests/check_requirements.bats
+++ b/tests/check_requirements.bats
@@ -205,3 +205,13 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" =~ [[:space:]]${dockerfile_major}[.] ]]
 }
+
+@test "Dockerfile baseimage har SHA256-digest for supply chain-sikkerhet" {
+    from_line=$(grep '^FROM postgres:' "$SAFEKEEPER_ROOT/Dockerfile")
+    [[ "$from_line" == *"@sha256:"* ]] || {
+        echo "FEIL: Dockerfile baseimage mangler SHA256-digest"
+        echo "Gjeldende linje: $from_line"
+        echo "Forventet format: FROM postgres:17-alpine@sha256:xxxxx"
+        return 1
+    }
+}


### PR DESCRIPTION
Fixes #149

Adds SHA256-digest pinning to the postgres:17-alpine baseimage to ensure deterministic Docker builds and prevent supply chain attacks.

**Changes:**
- Updated Dockerfile line 1 to use 
- Added test to verify digest is present in baseimage

**Verification:**
- All 104 BATS tests pass
- Docker build will be verified in CI