### PR TITLE
Fix #154: use explicit minor-version tag for postgres:17.10-alpine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Docker Compose (per app)
             +-- cleanup (retention lokalt + Hetzner)
 ```
 
-**Baseimage:** `postgres:17-alpine@sha256:0a8a1e76503c091f0feb387d51b10fcd746c2d61cf6cdd6e8356973a45e40a0f` (gir tilgang til `pg_dump`, `pg_isready`, `psql`). SHA256-digest påkrevd for supply chain-sikkerhet (CI sjekk i `tests/check_requirements.bats`)
+**Baseimage:** `postgres:17.10-alpine@sha256:0a8a1e76503c091f0feb387d51b10fcd746c2d61cf6cdd6e8356973a45e40a0f` (gir tilgang til `pg_dump`, `pg_isready`, `psql`). SHA256-digest påkrevd for supply chain-sikkerhet (CI sjekk i `tests/check_requirements.bats`)
 
 **Dependabot-policy for major-versjoner:** Ignoren for `version-update:semver-major` på docker er fjernet (fra #120). Dependabot foreslår automatisk PR-er ved PG18, PG19 osv. Disse auto-merges IKKE stille — drift-vakten i `tests/check_requirements.bats` gater majors ved å feile CI inntil `tests/stubs/pg_dump` bevisst oppdateres.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:17-alpine@sha256:0a8a1e76503c091f0feb387d51b10fcd746c2d61cf6cdd6e8356973a45e40a0f
+FROM postgres:17.10-alpine@sha256:0a8a1e76503c091f0feb387d51b10fcd746c2d61cf6cdd6e8356973a45e40a0f
 
 RUN apk update && apk upgrade --no-cache && apk add --no-cache \
     bash \


### PR DESCRIPTION
Fixes #154

## Endring
- Oppdaterer Dockerfile baseimage fra `postgres:17-alpine@sha256:...` til `postgres:17.10-alpine@sha256:...`
- Same SHA256-digest, men tag-delen er nå eksplisitt og hindrer fremtidig drift

## Verifikasjon
- ✓ Alle 104 BATS-tester passerer
- ✓ Docker-image bygges med ny tag
- ✓ CLAUDE.md oppdatert for konsistens

## Supply chain security
Dette gjør baseimage-pinningen mer robust ved å spesifisere minor-versjon sammen med SHA256-digest, som følger tidligere mønster fra issues #61 og #119.