### PR TITLE
Fix #151: expose SFTP/SSH timeout vars as configurable env vars

### DIFF
--- a/backup-entrypoint.sh
+++ b/backup-entrypoint.sh
@@ -41,6 +41,9 @@ HETZNER_HOST="${HETZNER_HOST:-}"
 HETZNER_USER="${HETZNER_USER:-}"
 HETZNER_PORT="${HETZNER_PORT:-23}"
 HETZNER_BACKUP_PATH="${HETZNER_BACKUP_PATH:-backups/${PROJECT_NAME}}"
+HETZNER_SFTP_CONNECT_TIMEOUT="${HETZNER_SFTP_CONNECT_TIMEOUT:-30}"
+HETZNER_SSH_ALIVE_INTERVAL="${HETZNER_SSH_ALIVE_INTERVAL:-15}"
+HETZNER_SSH_ALIVE_COUNT="${HETZNER_SSH_ALIVE_COUNT:-3}"
 
 # ntfy-varsling (tom = deaktivert)
 NTFY_URL="${NTFY_URL:-}"
@@ -52,9 +55,9 @@ CURRENT_BACKUP_FILE=""
 # sftp bruker -P (stor bokstav) for port, -q for stille modus.
 # ConnectTimeout/ServerAlive forhindrer at en hengt sftp-prosess arver LOCK_FD (flock)
 # og blokkerer fremtidige cron-backups i dagevis (rotaarsak for hwa/styreportal-incident 2026-06-07).
-SFTP_OPTS=(-q -i "${SSH_KEY}" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -P "${HETZNER_PORT}" -o ConnectTimeout=30 -o ServerAliveInterval=15 -o ServerAliveCountMax=3)
+SFTP_OPTS=(-q -i "${SSH_KEY}" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -P "${HETZNER_PORT}" -o ConnectTimeout="${HETZNER_SFTP_CONNECT_TIMEOUT}" -o ServerAliveInterval="${HETZNER_SSH_ALIVE_INTERVAL}" -o ServerAliveCountMax="${HETZNER_SSH_ALIVE_COUNT}")
 # SSH_OPTS brukes for sha256sum-verifisering som fallback naar SFTP ls -la er utilgjengelig (ssh bruker -p i stedet for -P)
-SSH_OPTS=(-i "${SSH_KEY}" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -p "${HETZNER_PORT}" -o ConnectTimeout=30 -o ServerAliveInterval=15 -o ServerAliveCountMax=3)
+SSH_OPTS=(-i "${SSH_KEY}" -o StrictHostKeyChecking=accept-new -o BatchMode=yes -p "${HETZNER_PORT}" -o ConnectTimeout="${HETZNER_SFTP_CONNECT_TIMEOUT}" -o ServerAliveInterval="${HETZNER_SSH_ALIVE_INTERVAL}" -o ServerAliveCountMax="${HETZNER_SSH_ALIVE_COUNT}")
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"; }
 
@@ -119,6 +122,12 @@ check_requirements() {
         [[ "$HETZNER_USER" =~ ^[a-zA-Z0-9_-]+$ ]] || error "HETZNER_USER inneholder ugyldige tegn: '$HETZNER_USER'"
         [[ "$HETZNER_PORT" =~ ^[0-9]+$ ]] && [[ "$HETZNER_PORT" -ge 1 ]] && [[ "$HETZNER_PORT" -le 65535 ]] \
             || error "HETZNER_PORT er ugyldig: '$HETZNER_PORT'"
+        [[ "$HETZNER_SFTP_CONNECT_TIMEOUT" =~ ^[0-9]+$ ]] && [[ "$HETZNER_SFTP_CONNECT_TIMEOUT" -ge 1 ]] \
+            || error "HETZNER_SFTP_CONNECT_TIMEOUT må være et positivt heltall >= 1, fikk: '$HETZNER_SFTP_CONNECT_TIMEOUT'"
+        [[ "$HETZNER_SSH_ALIVE_INTERVAL" =~ ^[0-9]+$ ]] && [[ "$HETZNER_SSH_ALIVE_INTERVAL" -ge 1 ]] \
+            || error "HETZNER_SSH_ALIVE_INTERVAL må være et positivt heltall >= 1, fikk: '$HETZNER_SSH_ALIVE_INTERVAL'"
+        [[ "$HETZNER_SSH_ALIVE_COUNT" =~ ^[0-9]+$ ]] && [[ "$HETZNER_SSH_ALIVE_COUNT" -ge 1 ]] \
+            || error "HETZNER_SSH_ALIVE_COUNT må være et positivt heltall >= 1, fikk: '$HETZNER_SSH_ALIVE_COUNT'"
         [[ "$HETZNER_BACKUP_PATH" =~ ^[a-zA-Z0-9._/-]+$ ]] || error "HETZNER_BACKUP_PATH inneholder ugyldige tegn: '$HETZNER_BACKUP_PATH'"
         [[ "$HETZNER_BACKUP_PATH" != *".."* ]] || error "HETZNER_BACKUP_PATH kan ikke inneholde '..'"
     fi

--- a/tests/check_requirements.bats
+++ b/tests/check_requirements.bats
@@ -206,6 +206,42 @@ teardown() {
     [[ "$output" =~ [[:space:]]${dockerfile_major}[.] ]]
 }
 
+@test "HETZNER_SFTP_CONNECT_TIMEOUT med ikke-numerisk verdi avvises" {
+    export PROJECT_NAME=testprosjekt
+    export DB_PASSWORD=hemmelig
+    export BACKUP_ENCRYPTION_KEY=nokkel
+    export HETZNER_HOST=hetzner.example.com
+    export HETZNER_USER=u12345
+    export HETZNER_SFTP_CONNECT_TIMEOUT="abc"
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"HETZNER_SFTP_CONNECT_TIMEOUT"* ]]
+}
+
+@test "HETZNER_SFTP_CONNECT_TIMEOUT=0 avvises" {
+    export PROJECT_NAME=testprosjekt
+    export DB_PASSWORD=hemmelig
+    export BACKUP_ENCRYPTION_KEY=nokkel
+    export HETZNER_HOST=hetzner.example.com
+    export HETZNER_USER=u12345
+    export HETZNER_SFTP_CONNECT_TIMEOUT=0
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"HETZNER_SFTP_CONNECT_TIMEOUT"* ]]
+}
+
+@test "HETZNER_SFTP_CONNECT_TIMEOUT=5 aksepteres" {
+    export PROJECT_NAME=testprosjekt
+    export DB_PASSWORD=hemmelig
+    export BACKUP_ENCRYPTION_KEY=nokkel
+    export HETZNER_HOST=hetzner.example.com
+    export HETZNER_USER=u12345
+    export HETZNER_SFTP_CONNECT_TIMEOUT=5
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"HETZNER_SFTP_CONNECT_TIMEOUT"* ]]
+}
+
 @test "Dockerfile baseimage har SHA256-digest for supply chain-sikkerhet" {
     from_line=$(grep '^FROM postgres:' "$SAFEKEEPER_ROOT/Dockerfile")
     [[ "$from_line" == *"@sha256:"* ]] || {

--- a/tests/hetzner_retry.bats
+++ b/tests/hetzner_retry.bats
@@ -222,3 +222,56 @@ teardown() {
 
     rm -f "$call_log"
 }
+
+@test "SFTP_OPTS bruker HETZNER_SFTP_CONNECT_TIMEOUT naar det er satt" {
+    export HETZNER_SFTP_CONNECT_TIMEOUT=5
+    local call_log
+    call_log="$(mktemp)"
+    export STUB_SFTP_CALL_LOG="$call_log"
+    export STUB_SFTP_LS_SIZE=7
+    load_backup_lib
+
+    local dummy="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
+    printf 'content' > "$dummy"
+
+    run upload_to_hetzner "$dummy"
+    [ "$status" -eq 0 ]
+
+    local sftp_args
+    sftp_args=$(cat "$call_log")
+    [[ "$sftp_args" == *"ConnectTimeout=5"* ]] || {
+        echo "FEIL: ConnectTimeout=5 mangler i sftp-kallet: $sftp_args" >&2
+        return 1
+    }
+
+    rm -f "$call_log"
+}
+
+@test "SFTP_OPTS bruker HETZNER_SSH_ALIVE_INTERVAL og HETZNER_SSH_ALIVE_COUNT naar de er satt" {
+    export HETZNER_SSH_ALIVE_INTERVAL=60
+    export HETZNER_SSH_ALIVE_COUNT=5
+    local call_log
+    call_log="$(mktemp)"
+    export STUB_SFTP_CALL_LOG="$call_log"
+    export STUB_SFTP_LS_SIZE=7
+    load_backup_lib
+
+    local dummy="$BACKUP_DIR/testprosjekt_20260101_120000.sql.gz.gpg"
+    printf 'content' > "$dummy"
+
+    run upload_to_hetzner "$dummy"
+    [ "$status" -eq 0 ]
+
+    local sftp_args
+    sftp_args=$(cat "$call_log")
+    [[ "$sftp_args" == *"ServerAliveInterval=60"* ]] || {
+        echo "FEIL: ServerAliveInterval=60 mangler i sftp-kallet: $sftp_args" >&2
+        return 1
+    }
+    [[ "$sftp_args" == *"ServerAliveCountMax=5"* ]] || {
+        echo "FEIL: ServerAliveCountMax=5 mangler i sftp-kallet: $sftp_args" >&2
+        return 1
+    }
+
+    rm -f "$call_log"
+}


### PR DESCRIPTION
Fixes #151

Exposes `HETZNER_SFTP_CONNECT_TIMEOUT` (default 30), `HETZNER_SSH_ALIVE_INTERVAL` (default 15), and `HETZNER_SSH_ALIVE_COUNT` (default 3) as env-var overrides in `backup-entrypoint.sh`.

- Replaces hardcoded values in `SFTP_OPTS` and `SSH_OPTS`
- Adds numeric ≥1 validation in `check_requirements` (within `HETZNER_HOST` block, consistent with `HETZNER_PORT`)
- Adds 2 BATS tests: configurable timeout propagates to sftp args; all 3 vars work independently
- Adds 3 BATS validation tests: non-numeric rejected, 0 rejected, valid value accepted
- Default values are identical to previous hardcoded values — no impact on existing setups

Finding #2 (apk-pinning): closed as won't-fix per triage decision.