### PR TITLE
test+docs: QA-funn fra #151 — valideringstester for SSH_ALIVE-variabler + CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,9 @@ openssl rand -base64 32
 | `HETZNER_USER` | Hetzner StorageBox brukernavn | (tom) | Nei |
 | `HETZNER_PORT` | Hetzner SSH-port | `23` | Nei |
 | `HETZNER_BACKUP_PATH` | Sti pa StorageBox | `backups/${PROJECT_NAME}` | Nei |
+| `HETZNER_SFTP_CONNECT_TIMEOUT` | ConnectTimeout (sekunder) for SFTP/SSH-tilkobling til StorageBox | `30` | Nei |
+| `HETZNER_SSH_ALIVE_INTERVAL` | ServerAliveInterval (sekunder) for SFTP/SSH | `15` | Nei |
+| `HETZNER_SSH_ALIVE_COUNT` | ServerAliveCountMax for SFTP/SSH | `3` | Nei |
 | `NTFY_URL` | ntfy.sh-URL for proaktiv varsling ved backup-feil (tom = deaktivert) | (tom) | Nei |
 
 ## Sikkerhet

--- a/tests/check_requirements.bats
+++ b/tests/check_requirements.bats
@@ -242,6 +242,54 @@ teardown() {
     [[ "$output" != *"HETZNER_SFTP_CONNECT_TIMEOUT"* ]]
 }
 
+@test "HETZNER_SSH_ALIVE_INTERVAL med ikke-numerisk verdi avvises" {
+    export PROJECT_NAME=testprosjekt
+    export DB_PASSWORD=hemmelig
+    export BACKUP_ENCRYPTION_KEY=nokkel
+    export HETZNER_HOST=hetzner.example.com
+    export HETZNER_USER=u12345
+    export HETZNER_SSH_ALIVE_INTERVAL="abc"
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"HETZNER_SSH_ALIVE_INTERVAL"* ]]
+}
+
+@test "HETZNER_SSH_ALIVE_INTERVAL=0 avvises" {
+    export PROJECT_NAME=testprosjekt
+    export DB_PASSWORD=hemmelig
+    export BACKUP_ENCRYPTION_KEY=nokkel
+    export HETZNER_HOST=hetzner.example.com
+    export HETZNER_USER=u12345
+    export HETZNER_SSH_ALIVE_INTERVAL=0
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"HETZNER_SSH_ALIVE_INTERVAL"* ]]
+}
+
+@test "HETZNER_SSH_ALIVE_COUNT med ikke-numerisk verdi avvises" {
+    export PROJECT_NAME=testprosjekt
+    export DB_PASSWORD=hemmelig
+    export BACKUP_ENCRYPTION_KEY=nokkel
+    export HETZNER_HOST=hetzner.example.com
+    export HETZNER_USER=u12345
+    export HETZNER_SSH_ALIVE_COUNT="abc"
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"HETZNER_SSH_ALIVE_COUNT"* ]]
+}
+
+@test "HETZNER_SSH_ALIVE_COUNT=0 avvises" {
+    export PROJECT_NAME=testprosjekt
+    export DB_PASSWORD=hemmelig
+    export BACKUP_ENCRYPTION_KEY=nokkel
+    export HETZNER_HOST=hetzner.example.com
+    export HETZNER_USER=u12345
+    export HETZNER_SSH_ALIVE_COUNT=0
+    run bash "$SAFEKEEPER_ROOT/backup-entrypoint.sh" backup
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"HETZNER_SSH_ALIVE_COUNT"* ]]
+}
+
 @test "Dockerfile baseimage har SHA256-digest for supply chain-sikkerhet" {
     from_line=$(grep '^FROM postgres:' "$SAFEKEEPER_ROOT/Dockerfile")
     [[ "$from_line" == *"@sha256:"* ]] || {


### PR DESCRIPTION
Oppfølging til #157 (issue #151).

QA-review etter merge av #157 identifiserte:
- Manglende valideringstester for `HETZNER_SSH_ALIVE_INTERVAL` og `HETZNER_SSH_ALIVE_COUNT` (kun `HETZNER_SFTP_CONNECT_TIMEOUT` hadde tester)
- `CLAUDE.md` manglet dokumentasjon for de tre nye env-variablene

Denne PR-en fikser begge funnene:
- 4 nye BATS-tester i `check_requirements.bats`: ikke-numerisk og =0 avvises for begge variabler
- 3 nye rader i miljøvariabel-tabellen i `CLAUDE.md`