### PR TITLE
Fix #161: docs: CLAUDE.md apper-tabell refererer til vinforalle som ble arkivert 2026-06-19

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,7 +266,6 @@ backup:
 | 6810 | `/mnt/nas-apps/6810/backups` | Aktiv | `0 2 * * *` |
 | styreportal | `/mnt/nas-apps/styreportal/backups` | Venter pa opprettelse | `30 1 * * *` |
 | maskemester | `/mnt/nas-apps/maskemester/backups` | Ikke satt opp | `0 5 * * *` |
-| vinforalle | `/mnt/nas-apps/vinforalle/backups` | Ikke satt opp | `0 5 * * *` |
 | smart-casual | — | — | Ikke konfigurert |
 
 ### Kryssrepo-avhengigheter


### PR DESCRIPTION
Fixes #161

Automatisk fiks av small-sak via Mistral-agent (aider / mistral/mistral-medium-latest). Del av #1097.