### PR TITLE
Fix #163: docs: README.md mangler tre Hetzner SSH-miljøvariabler lagt til i #151

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Alt styres via miljovariabler - ingen prosjektspesifikk kode.
 | `HETZNER_HOST` | Hetzner StorageBox hostname | (tom = deaktivert) | Nei |
 | `HETZNER_USER` | Hetzner StorageBox brukernavn | (tom) | Nei |
 | `HETZNER_PORT` | Hetzner SSH-port | `23` | Nei |
+| `HETZNER_SFTP_CONNECT_TIMEOUT` | ConnectTimeout (sekunder) for SFTP/SSH-tilkobling til StorageBox | `30` | Nei |
+| `HETZNER_SSH_ALIVE_INTERVAL` | ServerAliveInterval (sekunder) for SFTP/SSH | `15` | Nei |
+| `HETZNER_SSH_ALIVE_COUNT` | ServerAliveCountMax for SFTP/SSH | `3` | Nei |
 | `HETZNER_BACKUP_PATH` | Sti pa StorageBox | `backups/${PROJECT_NAME}` | Nei |
 | `NTFY_URL` | ntfy.sh-URL for proaktiv varsling ved backup-feil | (tom = deaktivert) | Nei |
 


### PR DESCRIPTION
Fixes #163

Automatisk fiks av small-sak via Mistral-agent (aider / mistral/mistral-medium-latest). Del av #1097.